### PR TITLE
use ruby 2.4.1 and a bundle cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.3
+  - 2.4.1
+cache: bundler
 before_install: gem install bundler -v 1.14.6
 before_script:
   - jdk_switcher use oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 rvm:
   - 2.4.1
+jdk:
+  - oraclejdk8
 cache: bundler
 before_install: gem install bundler -v 1.14.6
-before_script:
-  - jdk_switcher use oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ rvm:
 jdk:
   - oraclejdk8
 cache: bundler
-before_install: gem install bundler -v 1.14.6

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/sul-dlss/arclight.svg?branch=master)](https://travis-ci.org/sul-dlss/arclight)
+
 # Arclight
 
 Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/arclight`. To experiment with that code, run `bin/console` for an interactive prompt.


### PR DESCRIPTION
Any reason we shouldn't be running the latest ruby version (2.4.1)?

This PR also fixes #118.