### PR TITLE
Add a .solr_wrapper configuration file.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,6 @@ Metrics/LineLength:
   Max: 120
   Exclude:
     - 'Gemfile'
-    - 'tasks/arclight.rake'
 
 Metrics/ModuleLength:
   Max: 120

--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,0 +1,5 @@
+# Place any default configuration for solr_wrapper here
+# port: 8983
+collection:
+  dir: solr/conf/
+  name: blacklight-core

--- a/tasks/arclight.rake
+++ b/tasks/arclight.rake
@@ -10,7 +10,7 @@ EngineCart.fingerprint_proc = EngineCart.rails_fingerprint_proc
 desc 'Run test suite'
 task ci: ['arclight:generate'] do
   SolrWrapper.wrap do |solr|
-    solr.with_collection(name: 'blacklight-core', dir: File.join(File.expand_path('..', File.dirname(__FILE__)), 'solr', 'conf')) do
+    solr.with_collection do
       Rake::Task['arclight:seed'].invoke
       within_test_app do
         ## Do stuff inside arclight app here
@@ -35,8 +35,8 @@ namespace :arclight do
       Rake::Task['engine_cart:generate'].invoke
     end
 
-    SolrWrapper.wrap(port: '8983') do |solr|
-      solr.with_collection(name: 'blacklight-core', dir: File.join(File.expand_path('..', File.dirname(__FILE__)), 'solr', 'conf')) do
+    SolrWrapper.wrap do |solr|
+      solr.with_collection do
         Rake::Task['arclight:seed'].invoke
         within_test_app do
           system "bundle exec rails s #{args[:rails_server_args]}"


### PR DESCRIPTION
This allows us to start the solr index and the rails app separately while we're developing.