### PR TITLE
Add Creator and Names facets

### DIFF
--- a/lib/arclight/custom_document.rb
+++ b/lib/arclight/custom_document.rb
@@ -17,5 +17,17 @@ module Arclight
       t.accessrestrict(path: 'archdesc/accessrestrict/p', index_as: %i[displayable])
       t.scopecontent(path: 'archdesc/scopecontent/p', index_as: %i[displayable])
     end
+
+    def to_solr(solr_doc = {})
+      super
+      Solrizer.insert_field(solr_doc, 'names', names, :facetable)
+      solr_doc
+    end
+
+    private
+
+    def names
+      [corpname, famname, name, persname].flatten.compact.uniq
+    end
   end
 end

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -71,6 +71,7 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'creator_sim', label: 'Creator'
     config.add_facet_field 'level_sim', label: 'Level'
+    config.add_facet_field 'names_sim', label: 'Names'
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -69,6 +69,7 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
+    config.add_facet_field 'creator_sim', label: 'Creator'
     config.add_facet_field 'level_sim', label: 'Level'
 
     # Have BL send all facet field names to Solr, which has been the default

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -208,6 +208,7 @@
        <str name="facet.mincount">1</str>
        <str name="facet.field">level_sim</str>
        <str name="facet.field">creator_sim</str>
+       <str name="facet.field">names_sim</str>
 
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -207,6 +207,7 @@
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
        <str name="facet.field">level_sim</str>
+       <str name="facet.field">creator_sim</str>
 
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>

--- a/spec/features/arclight_spec.rb
+++ b/spec/features/arclight_spec.rb
@@ -55,8 +55,11 @@ RSpec.describe 'Arclight', type: :feature do
 
       within('#facets') do
         expect(page).to have_css('h3 a', text: 'Level')
+        expect(page).to have_css('li .facet-label', text: 'series', visible: false)
         expect(page).to have_css('h3 a', text: 'Creator')
+        expect(page).to have_css('li .facet-label', text: 'Alpha Omega Alpha', visible: false)
         expect(page).to have_css('h3 a', text: 'Names')
+        expect(page).to have_css('li .facet-label', text: '1118 Badger Vine Special Collections', visible: false)
       end
     end
   end

--- a/spec/features/arclight_spec.rb
+++ b/spec/features/arclight_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe 'Arclight', type: :feature do
       within('#facets') do
         expect(page).to have_css('h3 a', text: 'Level')
         expect(page).to have_css('h3 a', text: 'Creator')
+        expect(page).to have_css('h3 a', text: 'Names')
       end
     end
   end

--- a/spec/features/arclight_spec.rb
+++ b/spec/features/arclight_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe 'Arclight', type: :feature do
 
       within('#facets') do
         expect(page).to have_css('h3 a', text: 'Level')
+        expect(page).to have_css('h3 a', text: 'Creator')
       end
     end
   end


### PR DESCRIPTION
This PR fixes #5.

![screen shot 2017-04-14 at 1 27 08 pm](https://cloud.githubusercontent.com/assets/1861171/25055243/796651a4-2116-11e7-8436-32f86df52812.png)

Note that none of the custom indexing code has specs ... we're testing the display of the fields, but that doesn't work for the facets. should we introduce specs for the custom indexing directly?