### PR TITLE
add the Level facet with machine/human-readable values

### DIFF
--- a/lib/arclight/custom_component.rb
+++ b/lib/arclight/custom_component.rb
@@ -9,14 +9,38 @@ module Arclight
     extend_terminology do |t|
       t.unitid(path: 'c/did/unitid', index_as: %i[displayable])
       t.creator(path: "c/did/origination[@label='creator']/*/text()", index_as: %i[displayable facetable])
+      t.otherlevel(path: 'c/@otherlevel', index_as: %i[displayable])
 
       # overrides of solr_ead to get different `index_as` properties
       t.ref_(path: '/c/@id', index_as: %i[displayable])
-      t.level(path: 'c/@level', index_as: %i[displayable facetable])
+      t.level(path: 'c/@level', index_as: %i[displayable]) # machine-readable for string `level_ssm`
       t.extent(path: 'c/did/physdesc/extent', index_as: %i[displayable])
       t.unitdate(path: 'c/did/unitdate', index_as: %i[displayable])
       t.accessrestrict(path: 'c/accessrestrict/p', index_as: %i[displayable])
       t.scopecontent(path: 'c/scopecontent/p', index_as: %i[displayable])
+    end
+
+    def to_solr(solr_doc = {})
+      super
+      Solrizer.insert_field(solr_doc, 'level', formatted_level, :facetable) # human-readable for facet `level_sim`
+      solr_doc
+    end
+
+    private
+
+    # @see http://eadiva.com/2/c/
+    def formatted_level
+      # terminology definitions for level yield Arrays and in this case single values
+      # TODO: OM changes the behavior of `level = level.first` such that it always returns `nil`
+      #       so need our own local variable here
+      actual_level = level.first.to_s if level.respond_to? :first
+
+      if actual_level == 'otherlevel'
+        alternative_level = otherlevel.first.to_s if otherlevel.respond_to? :first
+        alternative_level.present? ? alternative_level : 'Other'
+      elsif actual_level.present?
+        actual_level.capitalize
+      end
     end
   end
 end

--- a/lib/arclight/custom_document.rb
+++ b/lib/arclight/custom_document.rb
@@ -20,6 +20,8 @@ module Arclight
 
     def to_solr(solr_doc = {})
       super
+      Solrizer.insert_field(solr_doc, 'level', 'collection', :displayable) # machine-readable
+      Solrizer.insert_field(solr_doc, 'level', 'Collection', :facetable) # human-readable
       Solrizer.insert_field(solr_doc, 'names', names, :facetable)
       solr_doc
     end

--- a/spec/features/arclight_spec.rb
+++ b/spec/features/arclight_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Arclight', type: :feature do
           expect(page).to have_css('h3 a', text: 'Level')
           expect(page).to have_css('li .facet-label', text: 'Series', visible: false) # level != "otherlevel"
           expect(page).to have_css('li .facet-label', text: 'Mixed File', visible: false) # "otherlevel" with alt value
-          expect(page).to have_css('li .facet-label', text: 'Other', visible: false) # "otherlevel" but missing alt value
+          expect(page).to have_css('li .facet-label', text: 'Other', visible: false) # "otherlevel" but missing alt val
         end
 
         within('.blacklight-creator_sim') do

--- a/spec/features/arclight_spec.rb
+++ b/spec/features/arclight_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe 'Arclight', type: :feature do
 
         within('.blacklight-level_sim') do
           expect(page).to have_css('h3 a', text: 'Level')
-          expect(page).to have_css('li .facet-label', text: 'series', visible: false)
+          expect(page).to have_css('li .facet-label', text: 'Series', visible: false) # level != "otherlevel"
+          expect(page).to have_css('li .facet-label', text: 'Mixed File', visible: false) # "otherlevel" with alt value
+          expect(page).to have_css('li .facet-label', text: 'Other', visible: false) # "otherlevel" but missing alt value
         end
 
         within('.blacklight-creator_sim') do

--- a/spec/features/indexing_custom_component_spec.rb
+++ b/spec/features/indexing_custom_component_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Indexing Custom Component', type: :feature do
+  let(:components) do # an Array<Arclight::CustomComponent>
+    options = { component: Arclight::CustomComponent }
+    ENV['SOLR_URL'] = Blacklight.connection_config[:url]
+    indexer = SolrEad::Indexer.new(options) # `initialize` requires a solr connection
+
+    components = []
+    indexer.components('spec/fixtures/ead/alphaomegaalpha.xml').each do |node|
+      components << indexer.send(:om_component_from_node, node) # private method :(
+    end
+    components
+  end
+
+  context 'solrizer' do
+    it '#level' do
+      doc = components[0].to_solr
+      expect(doc['level_ssm'].first).to eq 'series'
+      expect(doc['level_sim'].first).to eq 'Series'
+
+      doc = components[2].to_solr
+      expect(doc['level_ssm'].first).to eq 'otherlevel'
+      expect(doc['level_sim'].first).to eq 'Mixed File'
+
+      doc = components[3].to_solr
+      expect(doc['level_ssm'].first).to eq 'otherlevel'
+      expect(doc['level_sim'].first).to eq 'Other'
+    end
+  end
+end

--- a/spec/features/indexing_custom_document_spec.rb
+++ b/spec/features/indexing_custom_document_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Indexing Custom Document', type: :feature do
+  subject do
+    Arclight::CustomDocument.from_xml(File.read('spec/fixtures/ead/alphaomegaalpha.xml'))
+  end
+
+  context 'solrizer' do
+    let(:doc) { subject.to_solr }
+
+    it '#level' do
+      expect(doc['level_ssm'].first).to eq 'collection'
+      expect(doc['level_sim'].first).to eq 'Collection'
+    end
+
+    it '#unitid' do
+      expect(doc['unitid_ssm'].first).to eq 'MS C 271'
+    end
+
+    it '#repository' do
+      expect(doc['repository_ssm'].first).to eq '1118 Badger Vine Special Collections'
+      expect(doc['repository_sim'].first).to eq '1118 Badger Vine Special Collections'
+    end
+
+    it '#creator' do
+      expect(doc['creator_ssm'].first).to eq 'Alpha Omega Alpha'
+      expect(doc['creator_sim'].first).to eq 'Alpha Omega Alpha'
+    end
+
+    it '#extent' do
+      expect(doc['extent_ssm'].first).to match(/^15\.0 linear feet/)
+    end
+
+    it '#unitdate' do
+      expect(doc['unitdate_ssm'].first).to eq '1894-1992'
+    end
+
+    it '#accessrestrict' do
+      expect(doc['accessrestrict_ssm'].first).to eq 'No restrictions on access.'
+    end
+
+    it '#scopecontent' do
+      expect(doc['scopecontent_ssm'].first).to match(/^Correspondence, documents/)
+    end
+
+    it '#names' do
+      expect(doc['names_sim']).to include 'Root, William Webster, 1867-1932'
+    end
+  end
+end

--- a/spec/fixtures/ead/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/alphaomegaalpha.xml
@@ -177,7 +177,7 @@
             </dao>
           </did>
         </c>
-        <c id="aspace_e6db65d47e891d61d69c2798c68a8f02" level="otherlevel">
+        <c id="aspace_e6db65d47e891d61d69c2798c68a8f02" level="otherlevel" otherlevel="Mixed File">
           <did>
             <unittitle>Statements of purpose,</unittitle>
             <unitdate>c.1902</unitdate>


### PR DESCRIPTION
This PR fixes #14. 

Note that `level_ssm` is as-is data from `@level` and `level_sim` is the human readable version. It also adds some new specs for our custom indexing code. 

Note that the CustomComponent spec is a little hairy due to how `solr_ead` works for components. We can refactor it to look more like the CustomDocument code, but AFAIK we'd have to create fixture files that just had the XML for the component.

## What it looks like:

![screen shot 2017-04-17 at 2 45 20 pm](https://cloud.githubusercontent.com/assets/1861171/25106076/811a7200-237c-11e7-919c-050a90ce5955.png)

"Mixed File" is the special case when level=otherlevel and otherlevel is present -- see the XML fixture change