### PR TITLE
add geogname facet

### DIFF
--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -74,6 +74,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'level_sim', label: 'Level'
     config.add_facet_field 'names_sim', label: 'Names'
     config.add_facet_field 'repository_sim', label: 'Repository'
+    config.add_facet_field 'geogname_sim', label: 'Place'
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -91,6 +92,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'extent_ssm', label: 'Physical Description'
     config.add_index_field 'accessrestrict_ssm', label: 'Conditions Governing Access'
     config.add_index_field 'collection_ssm', label: 'Collection Title'
+    config.add_index_field 'geogname_ssm', label: 'Place'
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -104,6 +106,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'extent_ssm', label: 'Physical Description'
     config.add_show_field 'accessrestrict_ssm', label: 'Conditions Governing Access'
     config.add_show_field 'collection_ssm', label: 'Collection Title'
+    config.add_show_field 'geogname_ssm', label: 'Place'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -195,6 +195,7 @@
          collection_ssm,
          creator_ssm,
          extent_ssm,
+         geogname_ssm,
          language_ssm,
          level_ssm,
          repository_ssm,
@@ -212,6 +213,7 @@
        <str name="facet.field">level_sim</str>
        <str name="facet.field">creator_sim</str>
        <str name="facet.field">names_sim</str>
+       <str name="facet.field">geogname_sim</str>
 
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>

--- a/spec/features/arclight_spec.rb
+++ b/spec/features/arclight_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe 'Arclight', type: :feature do
 
       expect(page).to have_css('dt', text: 'Creator')
       expect(page).to have_css('dd', text: 'Alpha Omega Alpha')
+
+      expect(page).to have_css('dt', text: 'Place')
+      expect(page).to have_css('dd', text: 'Mindanao Island (Philippines)')
     end
 
     it 'renders metadata to meet minumum DACS requirements for a component'
@@ -73,6 +76,11 @@ RSpec.describe 'Arclight', type: :feature do
         within('.blacklight-repository_sim') do
           expect(page).to have_css('h3 a', text: 'Repository')
           expect(page).to have_css('li .facet-label', text: '1118 Badger Vine Special Collections', visible: false)
+        end
+
+        within('.blacklight-geogname_sim') do
+          expect(page).to have_css('h3 a', text: 'Place')
+          expect(page).to have_css('li .facet-label', text: 'Mindanao Island (Philippines)', visible: false)
         end
       end
     end
@@ -110,6 +118,9 @@ RSpec.describe 'Arclight', type: :feature do
 
       expect(page).to have_css('dt', text: 'Creator')
       expect(page).to have_css('dd', text: 'Alpha Omega Alpha')
+
+      expect(page).to have_css('dt', text: 'Place')
+      expect(page).to have_css('dd', text: 'Mindanao Island (Philippines)')
     end
 
     it 'renders metadata to meet minumum DACS requirements for a component'

--- a/spec/fixtures/ead/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/alphaomegaalpha.xml
@@ -143,6 +143,7 @@
       <corpname role="fmo" source="ingest">Alpha Omega Alpha</corpname>
       <persname source="mesh">Root, William Webster, 1867-1932</persname>
       <persname source="mesh">Bierring, Walter L. (Walter Lawrence), 1868-1961</persname>
+      <geogname source="lcsh">Mindanao Island (Philippines)</geogname>
     </controlaccess>
     <dsc>
       <c id="aspace_563a320bb37d24a9e1e6f7bf95b52671" level="series">


### PR DESCRIPTION
This PR fixes #143. It adds the `geogname_sim` facet and puts the `geoname_ssm` on the search results and show page (for now).

![screen shot 2017-04-18 at 11 47 49 am](https://cloud.githubusercontent.com/assets/1861171/25147663/2108167c-242d-11e7-8599-6c140c9946c1.png)

Note that the fixture is hand-edited to add a `geogname` element -- as described here http://eadiva.com/2/geogname/