### PR TITLE
Change from dismax to edismax in our default request handler.

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -69,7 +69,7 @@
          will be overridden by parameters in the request
       -->
      <lst name="defaults">
-       <str name="defType">dismax</str>
+       <str name="defType">edismax</str>
        <str name="echoParams">explicit</str>
        <int name="rows">10</int>
 


### PR DESCRIPTION
This will start having solr behave more as expected (e.g. `q=*:*` returns results).