### PR TITLE
add multifield facet based on subfields of controlaccess

### DIFF
--- a/lib/arclight/custom_document.rb
+++ b/lib/arclight/custom_document.rb
@@ -12,6 +12,8 @@ module Arclight
       t.repository(path: 'archdesc/did/repository/corpname/text() | archdesc/did/repository/name/text()', index_as: %i[displayable facetable])
       t.creator(path: "archdesc/did/origination[@label='creator']/*/text()", index_as: %i[displayable facetable])
       t.prefercite(path: 'archdesc/prefercite/p', index_as: %i[displayable])
+      t.function(path: 'archdesc/controlaccess/function/text()', index_as: %i[displayable facetable])
+      t.occupation(path: 'archdesc/controlaccess/occupation/text()', index_as: %i[displayable facetable])
 
       # overrides of solr_ead to get different `index_as` properties
       t.extent(path: 'archdesc/did/physdesc/extent', index_as: %i[displayable])
@@ -29,6 +31,7 @@ module Arclight
       Solrizer.insert_field(solr_doc, 'level', 'Collection', :facetable) # human-readable
       Solrizer.insert_field(solr_doc, 'names', names, :facetable)
       Solrizer.insert_field(solr_doc, 'date_range', formatted_unitdate_for_range, :facetable)
+      Solrizer.insert_field(solr_doc, 'access_subjects', access_subjects, :facetable)
       solr_doc
     end
 
@@ -36,6 +39,35 @@ module Arclight
 
     def names
       [corpname, famname, name, persname].flatten.compact.uniq - repository
+    end
+
+    # Combine subjets into one group from:
+    #  <controlaccess/><subject></subject>
+    #  <controlaccess/><function></function>
+    #  <controlaccess/><genreform></genreform>
+    #  <controlaccess/><occupation></occupation>
+    def access_subjects
+      subjects = search("//*[local-name()='subject' or local-name()='function' or local-name() = 'occupation' or local-name() = 'genreform']").to_a
+      clean_facets_array(subjects.flatten.map(&:text))
+    end
+
+    # Return a cleaned array of facets without marc subfields
+    #
+    # E.g. clean_facets_array(['FacetValue1 |z FacetValue2','FacetValue3']) => ['FacetValue1 -- FacetValue2', 'FacetValue3']
+    def clean_facets_array(facets_array)
+      Array(facets_array).map { |text| fix_subfield_demarcators(text) }.compact.uniq
+    end
+
+    # Replace MARC style subfield demarcators
+    #
+    # Usage: fix_subfield_demarcators("Subject 1 |z Sub-Subject 2") => "Subject 1 -- Sub-Subject 2"
+    def fix_subfield_demarcators(value)
+      value.gsub(/\|\w{1}/, '--')
+    end
+
+    # Wrap OM's find_by_xpath for convenience
+    def search(path)
+      find_by_xpath(path) # rubocop:disable DynamicFindBy
     end
   end
 end

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -76,6 +76,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'names_sim', label: 'Names'
     config.add_facet_field 'repository_sim', label: 'Repository'
     config.add_facet_field 'geogname_sim', label: 'Place'
+    config.add_facet_field 'access_subjects_sim', label: 'Subject'
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -215,6 +215,7 @@
        <str name="facet.field">date_range_sim</str>
        <str name="facet.field">names_sim</str>
        <str name="facet.field">geogname_sim</str>
+       <str name="facet.field">access_subjects_sim</str>
 
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>

--- a/spec/features/arclight_spec.rb
+++ b/spec/features/arclight_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe 'Arclight', type: :feature do
           expect(page).to have_css('h3 a', text: 'Place')
           expect(page).to have_css('li .facet-label', text: 'Mindanao Island (Philippines)', visible: false)
         end
+
+        within('.blacklight-access_subjects_sim') do
+          expect(page).to have_css('h3 a', text: 'Subject')
+          expect(page).to have_css('li .facet-label', text: 'Societies', visible: false)
+          expect(page).to have_css('li .facet-label', text: 'Fraternizing', visible: false)
+          expect(page).to have_css('li .facet-label', text: 'Photographs', visible: false)
+          expect(page).to have_css('li .facet-label', text: 'Medicine', visible: false)
+        end
       end
     end
   end

--- a/spec/features/indexing_custom_document_spec.rb
+++ b/spec/features/indexing_custom_document_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe 'Indexing Custom Document', type: :feature do
       expect(doc['names_sim']).to include 'Root, William Webster, 1867-1932'
     end
 
+    it '#access_subjects' do
+      expect(doc['access_subjects_sim']).to include 'Fraternizing'
+    end
+
     describe '#date_range' do
       it 'includes an array of all the years in a particular unit-date range described in YYYY/YYYY format' do
         date_range_field = doc['date_range_sim']


### PR DESCRIPTION
Adopted code from https://github.com/NYULibraries/ead_indexer/blob/master/lib/ead_indexer/behaviors.rb#L55-L58 to add a multi field facet based on subfields of archdesc/controlaccess/