### PR TITLE
move arclight:index* tasks into shared tasks and some minor cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,8 @@ RSpec::Core::RakeTask.new(:spec)
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
-load 'tasks/arclight.rake'
+Dir.glob('./tasks/*.rake').each { |f| load f }
+Dir.glob('./lib/tasks/*.rake').each { |f| load f }
 
 require 'engine_cart/rake_task'
 require 'solr_ead'

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'arclight'
+
+namespace :arclight do
+  desc 'Index a document'
+  task :index do
+    raise 'Please specify your file, ex. FILE=<path/to/file.xml>' unless ENV['FILE']
+    indexer = load_indexer
+    indexer.update(ENV['FILE'])
+  end
+
+  desc 'Index a directory of documents'
+  task :index_dir do
+    raise 'Please specify your directory, ex. DIR=<path/to/directory>' unless ENV['DIR']
+    indexer = load_indexer
+    Dir.glob(File.join(ENV['DIR'], '*.xml')).each do |file|
+      print "Indexing #{File.basename(file)}..."
+      indexer.update(file)
+      print "done.\n"
+    end
+  end
+end
+
+def load_indexer
+  # hardcoded since we don't have access to Blacklight.connection_config[:url] here
+  ENV['SOLR_URL'] ||= 'http://127.0.0.1:8983/solr/blacklight-core'
+
+  options = {
+    document: Arclight::CustomDocument,
+    component: Arclight::CustomComponent
+  }
+  SolrEad::Indexer.new(options)
+end

--- a/tasks/arclight.rake
+++ b/tasks/arclight.rake
@@ -8,7 +8,7 @@ require 'arclight'
 EngineCart.fingerprint_proc = EngineCart.rails_fingerprint_proc
 
 desc 'Run test suite'
-task ci: ['arclight:generate'] do
+task ci: %w[arclight:generate] do
   SolrWrapper.wrap do |solr|
     solr.with_collection do
       Rake::Task['arclight:seed'].invoke
@@ -22,11 +22,10 @@ end
 
 namespace :arclight do
   desc 'Generate a test application'
-  task generate: ['engine_cart:generate'] do
-  end
+  task generate: %w[engine_cart:generate]
 
   desc 'Run Solr and Blacklight for interactive development'
-  task :server, [:rails_server_args] do |_t, args|
+  task :server, %i[rails_server_args] do |_t, args|
     if File.exist? EngineCart.destination
       within_test_app do
         system 'bundle update'
@@ -35,7 +34,9 @@ namespace :arclight do
       Rake::Task['engine_cart:generate'].invoke
     end
 
+    print 'Starting Solr...'
     SolrWrapper.wrap do |solr|
+      puts 'done.'
       solr.with_collection do
         Rake::Task['arclight:seed'].invoke
         within_test_app do
@@ -45,35 +46,8 @@ namespace :arclight do
     end
   end
 
-  desc 'Index a document'
-  task :index do
-    ENV['SOLR_URL'] = 'http://127.0.0.1:8983/solr/blacklight-core'
-    indexer = load_indexer
-    indexer.update(ENV['FILE'])
-  end
-
-  desc 'Index a directory of documents'
-  task :index_dir do
-    ENV['SOLR_URL'] = 'http://127.0.0.1:8983/solr/blacklight-core'
-    raise 'Please specify your directory, ex. DIR=<path/to/directory>' unless ENV['DIR']
-    indexer = load_indexer
-    Dir.glob(File.join(ENV['DIR'], '*')).each do |file|
-      print "Indexing #{File.basename(file)}..."
-      indexer.update(file) if File.extname(file) =~ /xml$/
-      print "done.\n"
-    end
-  end
-
   desc 'Seed fixture data to Solr'
   task :seed do
     system('DIR=./spec/fixtures/ead rake arclight:index_dir')
   end
-end
-
-def load_indexer
-  options = {
-    document: Arclight::CustomDocument,
-    component: Arclight::CustomComponent
-  }
-  SolrEad::Indexer.new(options)
 end


### PR DESCRIPTION
This PR lets the `arclight-demo` (or any other arclight) application use the `arclight:index*` tasks.