### PR TITLE
Collection details page base

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -16,4 +16,62 @@ module ArclightHelper
   def custom_show_content_classes
     'col-md-12 show-document'
   end
+
+  ##
+  # Defines custom helpers used for creating unique metadata blocks to render
+  Arclight::Engine.config.catalog_controller_field_accessors.each do |config_field|
+    ##
+    # Mimics what document_show_fields from Blacklight does
+    # https://github.com/projectblacklight/blacklight/blob/dee8d794125306ec8d4ab834a6a45bcf9671c791/app/helpers/blacklight/configuration_helper_behavior.rb#L35-L38
+    define_method(:"document_#{config_field}s") do |_document = nil|
+      blacklight_config.send(:"#{config_field}s")
+    end
+
+    ##
+    # Mimics what render_document_show_field_label from Blacklight does
+    # https://github.com/projectblacklight/blacklight/blob/dee8d794125306ec8d4ab834a6a45bcf9671c791/app/helpers/blacklight/blacklight_helper_behavior.rb#L136-L156
+    define_method(:"render_document_#{config_field}_label") do |*args|
+      options = args.extract_options!
+      document = args.first
+
+      field = options[:field]
+
+      t(:'blacklight.search.show.label', label: send(:"document_#{config_field}_label", document, field))
+    end
+
+    ##
+    # Mimics what document_show_field_label from Blacklight does
+    # https://github.com/projectblacklight/blacklight/blob/dee8d794125306ec8d4ab834a6a45bcf9671c791/app/helpers/blacklight/configuration_helper_behavior.rb#L67-L74
+    define_method(:"document_#{config_field}_label") do |document, field|
+      field_config = send(:"document_#{config_field}s", document)[field]
+      field_config ||= Blacklight::Configuration::NullField.new(key: field)
+
+      field_config.display_label('show')
+    end
+
+    ##
+    # Mimics what should_render_show_field? from Blacklight does
+    # https://github.com/projectblacklight/blacklight/blob/dee8d794125306ec8d4ab834a6a45bcf9671c791/app/helpers/blacklight/blacklight_helper_behavior.rb#L84-L92
+    define_method(:"should_render_#{config_field}?") do |document, field_config|
+      should_render_field?(field_config, document) && document_has_value?(document, field_config)
+    end
+  end
+
+  ##
+  # Calls the method for a configured field
+  def generic_document_fields(config_field)
+    send(:"document_#{config_field}s")
+  end
+
+  ##
+  # Calls the method for a configured field
+  def generic_should_render_field?(config_field, document, field)
+    send(:"should_render_#{config_field}?", document, field)
+  end
+
+  ##
+  # Calls the method for a configured field
+  def generic_render_document_field_label(config_field, document, field: field_name)
+    send(:"render_document_#{config_field}_label", document, field: field)
+  end
 end

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -10,4 +10,10 @@ module ArclightHelper
       link_to parent.label, solr_document_path(parent.global_id)
     end, t('arclight.breadcrumb_separator'))
   end
+
+  ##
+  # Classes used for customized show page in arclight
+  def custom_show_content_classes
+    'col-md-12 show-document'
+  end
 end

--- a/app/views/catalog/_custom_metadata.html.erb
+++ b/app/views/catalog/_custom_metadata.html.erb
@@ -1,0 +1,16 @@
+<% doc_presenter = show_presenter(document) %>
+
+<%= content_tag(:div, id: t("arclight.views.show.sections.#{field_accessor}").parameterize) do %>
+  <h3 class='al-show-sub-heading'>
+    <%= t("arclight.views.show.sections.#{field_accessor}") %>
+  </h3>
+
+  <dl class="row dl-invert">
+    <% generic_document_fields(field_accessor).each do |field_name, field| %>
+      <% if generic_should_render_field?(field_accessor, document, field) %>
+        <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= generic_render_document_field_label(field_accessor, document, field: field_name) %></dt>
+        <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field_name %></dd>
+      <% end %>
+    <% end %>
+  </dl>
+<% end %>

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -1,0 +1,10 @@
+<div class='row'>
+  <div class='col-md-3'>
+    <%= render partial: 'show_sidebar' %>
+  </div>
+  <div class='col-md-9'>
+    <% blacklight_config.show.metadata_partials.each do |metadata| %>
+      <%= render partial: 'custom_metadata', locals: { document: @document, field_accessor: metadata } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,0 +1,9 @@
+<div class='al-sidebar-navigation-overview'>
+  <ul class='nav flex-column'>
+    <% blacklight_config.show.metadata_partials.each do |item| %>
+      <li class='nav-item'>
+        <%= link_to t("arclight.views.show.sections.#{item}"), "##{t("arclight.views.show.sections.#{item}").parameterize}", class: 'nav-link' %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/layouts/catalog_result.html.erb
+++ b/app/views/layouts/catalog_result.html.erb
@@ -1,0 +1,7 @@
+<% content_for(:content) do %>
+  <section class="<%= show_content_classes %>">
+    <%= yield %>
+  </section>
+<% end %>
+
+<%= render template: "layouts/blacklight/base" %>

--- a/app/views/layouts/catalog_result.html.erb
+++ b/app/views/layouts/catalog_result.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:content) do %>
-  <section class="<%= show_content_classes %>">
+  <section class="<%= custom_show_content_classes %>">
     <%= yield %>
   </section>
 <% end %>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -3,4 +3,8 @@ en:
     views:
       home:
         heading: 'Archival Collections at Institution'
+      show:
+        sections:
+          summary_field: 'Summary'
+          access_field: 'Access and Use'
     breadcrumb_separator: ' » '

--- a/lib/arclight/custom_document.rb
+++ b/lib/arclight/custom_document.rb
@@ -10,12 +10,15 @@ module Arclight
       t.unitid(path: 'archdesc/did/unitid', index_as: %i[displayable])
       t.repository(path: 'archdesc/did/repository/corpname/text() | archdesc/did/repository/name/text()', index_as: %i[displayable facetable])
       t.creator(path: "archdesc/did/origination[@label='creator']/*/text()", index_as: %i[displayable facetable])
+      t.prefercite(path: 'archdesc/prefercite/p', index_as: %i[displayable])
 
       # overrides of solr_ead to get different `index_as` properties
       t.extent(path: 'archdesc/did/physdesc/extent', index_as: %i[displayable])
       t.unitdate(path: 'archdesc/did/unitdate', index_as: %i[displayable])
       t.accessrestrict(path: 'archdesc/accessrestrict/p', index_as: %i[displayable])
       t.scopecontent(path: 'archdesc/scopecontent/p', index_as: %i[displayable])
+      t.userestrict(path: 'archdesc/userestrict/p', index_as: %i[displayable])
+      t.abstract(path: 'archdesc/did/abstract', index_as: %i[displayable])
     end
 
     def to_solr(solr_doc = {})

--- a/lib/arclight/engine.rb
+++ b/lib/arclight/engine.rb
@@ -9,8 +9,14 @@ module Arclight
   ##
   # This is the defining class for the Arclight Rails Engine
   class Engine < ::Rails::Engine
+    Arclight::Engine.config.catalog_controller_field_accessors = %i[
+      summary_field access_field
+    ]
+
     initializer 'arclight.fields' do
-      Blacklight::Configuration.define_field_access :collection_access_field
+      Arclight::Engine.config.catalog_controller_field_accessors.each do |field|
+        Blacklight::Configuration.define_field_access field
+      end
     end
 
     initializer 'arclight.helpers' do

--- a/lib/arclight/engine.rb
+++ b/lib/arclight/engine.rb
@@ -9,6 +9,10 @@ module Arclight
   ##
   # This is the defining class for the Arclight Rails Engine
   class Engine < ::Rails::Engine
+    initializer 'arclight.fields' do
+      Blacklight::Configuration.define_field_access :collection_access_field
+    end
+
     initializer 'arclight.helpers' do
       ActionView::Base.send :include, ArclightHelper
     end

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -96,6 +96,8 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
+    # In Arclight these are shown in the "Summary" portion of the page for
+    # Collections
     config.add_show_field 'title_display', label: 'Title'
     config.add_show_field 'unitid_ssm', label: 'Unit ID'
     config.add_show_field 'repository_ssm', label: 'Repository'
@@ -104,7 +106,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'language_ssm', label: 'Language'
     config.add_show_field 'scopecontent_ssm', label: 'Scope Content'
     config.add_show_field 'extent_ssm', label: 'Physical Description'
-    config.add_show_field 'accessrestrict_ssm', label: 'Conditions Governing Access'
     config.add_show_field 'collection_ssm', label: 'Collection Title'
     config.add_show_field 'geogname_ssm', label: 'Place'
 
@@ -142,7 +143,15 @@ class CatalogController < ApplicationController
     config.autocomplete_path = 'suggest'
 
     ##
+    # Arclight Configurations
+
+    ##
     # Configuration for partials
     config.index.partials.insert(0, :index_breadcrumb)
+
+    # Collection Show Page - Access Section
+    config.add_collection_access_field 'accessrestrict_ssm', label: 'Conditions Governing Access'
+    config.add_collection_access_field 'userestrict_ssm', label: 'Terms Of Use'
+
   end
 end

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -96,18 +96,6 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    # In Arclight these are shown in the "Summary" portion of the page for
-    # Collections
-    config.add_show_field 'title_display', label: 'Title'
-    config.add_show_field 'unitid_ssm', label: 'Unit ID'
-    config.add_show_field 'repository_ssm', label: 'Repository'
-    config.add_show_field 'unitdate_ssm', label: 'Date'
-    config.add_show_field 'creator_ssm', label: 'Creator'
-    config.add_show_field 'language_ssm', label: 'Language'
-    config.add_show_field 'scopecontent_ssm', label: 'Scope Content'
-    config.add_show_field 'extent_ssm', label: 'Physical Description'
-    config.add_show_field 'collection_ssm', label: 'Collection Title'
-    config.add_show_field 'geogname_ssm', label: 'Place'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
@@ -148,10 +136,19 @@ class CatalogController < ApplicationController
     ##
     # Configuration for partials
     config.index.partials.insert(0, :index_breadcrumb)
+    
+    config.show.metadata_partials = [:summary_field, :access_field]
+    
+    # Collection Show Page - Summary Section
+    config.add_summary_field 'creator_ssm', label: 'Creator'
+    config.add_summary_field 'abstract_ssm', label: 'Abstract'
+    config.add_summary_field 'extent_ssm', label: 'Extent'
+    config.add_summary_field 'language_ssm', label: 'Language'
+    config.add_summary_field 'prefercite_ssm', label: 'Preferred citation'
 
     # Collection Show Page - Access Section
-    config.add_collection_access_field 'accessrestrict_ssm', label: 'Conditions Governing Access'
-    config.add_collection_access_field 'userestrict_ssm', label: 'Terms Of Use'
+    config.add_access_field 'accessrestrict_ssm', label: 'Conditions Governing Access'
+    config.add_access_field 'userestrict_ssm', label: 'Terms Of Use'
 
   end
 end

--- a/spec/arclight_spec.rb
+++ b/spec/arclight_spec.rb
@@ -6,4 +6,11 @@ RSpec.describe Arclight do
   it 'has a version number' do
     expect(Arclight::VERSION).not_to be nil
   end
+  describe 'Custom CatalogController field accessors' do
+    subject(:custom_fields) do
+      Arclight::Engine.config.catalog_controller_field_accessors
+    end
+
+    it { expect(custom_fields).to include :summary_field, :access_field }
+  end
 end

--- a/spec/features/arclight_spec.rb
+++ b/spec/features/arclight_spec.rb
@@ -89,42 +89,6 @@ RSpec.describe 'Arclight', type: :feature do
   end
 
   describe 'show page' do
-    it 'renders metadata to meet minumum DACS requirements for a collection' do
-      visit solr_document_path(id: 'aoa271')
-
-      expect(page).to have_css('h1', text: 'Alpha Omega Alpha Archives')
-
-      expect(page).to have_css('dt', text: 'Collection Title')
-      expect(page).to have_css('dd', text: 'Alpha Omega Alpha Archives')
-
-      expect(page).to have_css('dt', text: 'Unit ID')
-      expect(page).to have_css('dd', text: 'MS C 271')
-
-      expect(page).to have_css('dt', text: 'Repository')
-      expect(page).to have_css('dd', text: '1118 Badger Vine Special Collections')
-
-      expect(page).to have_css('dt', text: 'Date')
-      expect(page).to have_css('dd', text: '1894-1992')
-
-      expect(page).to have_css('dt', text: 'Language')
-      expect(page).to have_css('dd', text: /English/)
-
-      expect(page).to have_css('dt', text: 'Physical Description')
-      expect(page).to have_css('dd', text: /linear feet/)
-
-      expect(page).to have_css('dt', text: 'Scope Content')
-      expect(page).to have_css('dd', text: /Correspondence/)
-
-      expect(page).to have_css('dt', text: 'Conditions Governing Access')
-      expect(page).to have_css('dd', text: /No restrictions on access/)
-
-      expect(page).to have_css('dt', text: 'Creator')
-      expect(page).to have_css('dd', text: 'Alpha Omega Alpha')
-
-      expect(page).to have_css('dt', text: 'Place')
-      expect(page).to have_css('dd', text: 'Mindanao Island (Philippines)')
-    end
-
     it 'renders metadata to meet minumum DACS requirements for a component'
   end
   describe 'Search history' do

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Collection Page', type: :feature do
+  before do
+    visit solr_document_path(id: 'aoa271')
+  end
+  describe 'custom metadata sections' do
+    it 'summary has configured metadata' do
+      within '#summary' do
+        expect(page).to have_css('dt', text: 'Creator')
+        expect(page).to have_css('dd', text: 'Alpha Omega Alpha')
+        expect(page).to have_css('dt', text: 'Abstract')
+        expect(page).to have_css('dd', text: /was founded in 1902/)
+        expect(page).to have_css('dt', text: 'Extent')
+        expect(page).to have_css('dd', text: /15.0 linear feet/)
+        expect(page).to have_css('dt', text: 'Preferred citation')
+        expect(page).to have_css('dd', text: /Medicine, Bethesda, MD/)
+      end
+    end
+    it 'access and use has configured metadata' do
+      within '#access-and-use' do
+        expect(page).to have_css('dt', text: 'Conditions Governing Access')
+        expect(page).to have_css('dd', text: 'No restrictions on access.')
+        expect(page).to have_css('dt', text: 'Terms Of Use')
+        expect(page).to have_css('dd', text: /Copyright was transferred/)
+      end
+    end
+  end
+  describe 'navigation bar' do
+    it 'has configured links' do
+      within '.al-sidebar-navigation-overview' do
+        expect(page).to have_css 'a[href="#summary"]', text: 'Summary'
+        expect(page).to have_css 'a[href="#access-and-use"]', text: 'Access and Use'
+      end
+    end
+  end
+end

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -23,4 +23,55 @@ RSpec.describe ArclightHelper, type: :helper do
       expect(helper.parents_to_links(SolrDocument.new)).not_to include '»'
     end
   end
+  describe 'custom field accessors' do
+    let(:accessors) { Arclight::Engine.config.catalog_controller_field_accessors }
+    let(:field) { :yolo }
+
+    describe '#document_config_fields' do
+      it do
+        accessors.each do |accessor|
+          expect(helper).to respond_to :"document_#{accessor}s"
+        end
+      end
+    end
+    describe '#render_document_config_field_label' do
+      it do
+        accessors.each do |accessor|
+          expect(helper).to respond_to :"render_document_#{accessor}_label"
+        end
+      end
+    end
+    describe '#document_config_field_label' do
+      it do
+        accessors.each do |accessor|
+          expect(helper).to respond_to :"document_#{accessor}_label"
+        end
+      end
+    end
+    describe '#should_render_config_field?' do
+      it do
+        accessors.each do |accessor|
+          expect(helper).to respond_to :"should_render_#{accessor}?"
+        end
+      end
+    end
+    describe '#generic_document_fields' do
+      it 'send along the method call' do
+        expect(helper).to receive_messages(document_yolos: nil)
+        helper.generic_document_fields(field)
+      end
+    end
+    describe '#generic_should_render_field?' do
+      it 'send along the method call' do
+        expect(helper).to receive_messages(should_render_yolo?: nil)
+        helper.generic_should_render_field?(field, 0, 1)
+      end
+    end
+    describe '#generic_render_document_field_label?' do
+      it 'send along the method call' do
+        expect(helper).to receive_messages(render_document_yolo_label: nil)
+        helper.generic_render_document_field_label(field, 0, field: 1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #138 (uncompleted tasks were broken out as subtasks)

This PR implements the base structure of the collection detail page. To do this we built out a pattern for configurable metadata sections from within a consumers `catalog_controller.rb`

![screen shot 2017-04-19 at 7 41 12 pm](https://cloud.githubusercontent.com/assets/1656824/25206805/2c0b20f8-2538-11e7-9957-a01097408d70.png)

The tests for the generic DACS fields was removed since the design did not call for those fields.