### PR TITLE
issue #188

### DIFF
--- a/lib/arclight/custom_document.rb
+++ b/lib/arclight/custom_document.rb
@@ -10,7 +10,7 @@ module Arclight
     extend_terminology do |t|
       t.unitid(path: 'archdesc/did/unitid', index_as: %i[displayable])
       t.repository(path: 'archdesc/did/repository/corpname/text() | archdesc/did/repository/name/text()', index_as: %i[displayable facetable])
-      t.creator(path: "archdesc/did/origination[@label='creator']/*/text()", index_as: %i[displayable facetable])
+      t.creator(path: "archdesc/did/origination[@label='creator']/*/text()", index_as: %i[displayable facetable symbol])
       t.prefercite(path: 'archdesc/prefercite/p', index_as: %i[displayable])
       t.function(path: 'archdesc/controlaccess/function/text()', index_as: %i[displayable facetable])
       t.occupation(path: 'archdesc/controlaccess/occupation/text()', index_as: %i[displayable facetable])
@@ -44,7 +44,7 @@ module Arclight
       Solrizer.insert_field(solr_doc, 'names', names, :facetable)
       Solrizer.insert_field(solr_doc, 'date_range', formatted_unitdate_for_range, :facetable)
       Solrizer.insert_field(solr_doc, 'access_subjects', access_subjects, :facetable)
-      Solrizer.insert_field(solr_doc, 'all_subjects', all_subjects, :displayable)
+      Solrizer.insert_field(solr_doc, 'all_subjects', all_subjects, :symbol)
       solr_doc
     end
 

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -70,13 +70,15 @@ class CatalogController < ApplicationController
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
     config.add_facet_field 'collection_sim', label: 'Collection'
-    config.add_facet_field 'creator_sim', label: 'Creator'
+    config.add_facet_field 'creator_ssim', label: 'Creator'
     config.add_facet_field 'date_range_sim', label: 'Date range', range: true
     config.add_facet_field 'level_sim', label: 'Level'
     config.add_facet_field 'names_sim', label: 'Names'
     config.add_facet_field 'repository_sim', label: 'Repository'
     config.add_facet_field 'geogname_sim', label: 'Place'
-    config.add_facet_field 'access_subjects_sim', label: 'Subject'
+    # Temp disable access_subjects_ssim for later revision
+    #config.add_facet_field 'access_subjects_ssim', label: 'Subject'
+    config.add_facet_field 'all_subjects_ssim', label: 'All Subjects'
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -157,7 +159,7 @@ class CatalogController < ApplicationController
     ]
 
     # Collection Show Page - Summary Section
-    config.add_summary_field 'creator_ssm', label: 'Creator'
+    config.add_summary_field 'creator_ssim', label: 'Creator', :link_to_facet => true
     config.add_summary_field 'abstract_ssm', label: 'Abstract'
     config.add_summary_field 'extent_ssm', label: 'Extent'
     config.add_summary_field 'language_ssm', label: 'Language'
@@ -189,7 +191,7 @@ class CatalogController < ApplicationController
     config.add_related_field 'originalsloc_ssm', label: 'Location of originals'
 
     # Collection Show Page - Indexed Terms Section
-    config.add_indexed_terms_field 'all_subjects_ssm', label: 'Subjects', separator_options: {
+    config.add_indexed_terms_field 'all_subjects_ssim', label: 'Subjects', :link_to_facet => true, separator_options: {
       words_connector: '<br/>',
       two_words_connector: '<br/>',
       last_word_connector: '<br/>'

--- a/spec/features/indexing_custom_document_spec.rb
+++ b/spec/features/indexing_custom_document_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Indexing Custom Document', type: :feature do
     end
 
     it '#all_subjects' do
-      subjects = doc['all_subjects_ssm']
+      subjects = doc['all_subjects_ssim']
 
       expect(subjects.length).to eq 8
       expect(subjects.first).to eq 'Societies'

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Search resutls', type: :feature do
           expect(page).to have_css('li .facet-label', text: 'Other', visible: false) # "otherlevel" but missing alt val
         end
 
-        within('.blacklight-creator_sim') do
+        within('.blacklight-creator_ssim') do
           expect(page).to have_css('h3 a', text: 'Creator')
           expect(page).to have_css('li .facet-label', text: 'Alpha Omega Alpha', visible: false)
         end
@@ -91,8 +91,8 @@ RSpec.describe 'Search resutls', type: :feature do
           expect(page).to have_css('li .facet-label', text: 'Mindanao Island (Philippines)', visible: false)
         end
 
-        within('.blacklight-access_subjects_sim') do
-          expect(page).to have_css('h3 a', text: 'Subject')
+        within('.blacklight-all_subjects_ssim') do
+          expect(page).to have_css('h3 a', text: 'All Subjects')
           expect(page).to have_css('li .facet-label', text: 'Societies', visible: false)
           expect(page).to have_css('li .facet-label', text: 'Fraternizing', visible: false)
           expect(page).to have_css('li .facet-label', text: 'Photographs', visible: false)


### PR DESCRIPTION
After discussion during standup today (Wednesday 4-26-17) Mark noted that issue #188 was more complicated that just linking to the subjects facet. Linking to the appropriate facet types for subjects, names, and geo is desired.

Current this PR only creates links using the all_subjects_ssim facet. The previously used access_subject_sim has been temporarily disabled in the catalog_controller.rb file.

Jack had suggested to we modified all the _sim and _ssm references to _ssim but I ran into trouble trying that and those changes aren't included here.