### PR TITLE
[DO NOT MERGE] [wip] axe-matchers proof of concept for automated a11y testing

### DIFF
--- a/arclight.gemspec
+++ b/arclight.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 1.15.0'
   spec.add_development_dependency 'rspec-rails', '~> 3.0'
   spec.add_development_dependency 'solr_wrapper'
+  spec.add_development_dependency 'axe-matchers'
 end

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe 'Collection Page', type: :feature do
     visit solr_document_path(id: 'aoa271')
   end
 
+  describe 'accessibility review', driver: :poltergeist do
+    it 'complies to WCAG 2.0 AA guidelines' do
+      expect(page).to be_accessible.within('#main-container').according_to :wcag2aa
+    end
+  end
+
   describe 'arclight document header' do
     it 'includes a div with the repository and collection ID' do
       within('.al-document-title-bar') do

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -89,5 +89,12 @@ RSpec.describe 'Search resutls', type: :feature do
         end
       end
     end
+
+    describe 'accessibility review', driver: :poltergeist do
+      it 'complies to WCAG 2.0 AA guidelines', js: true do
+        visit search_catalog_path q: '', search_field: 'all_fields'
+        expect(page).to be_accessible.within('#main-container').according_to :wcag2aa
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require 'rspec/rails'
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
 
+require 'axe/rspec'
 require 'arclight'
 
 RSpec.configure do |config|


### PR DESCRIPTION
uses axe-matchers (and aXe Core API): https://www.deque.com/products/axe/