### PR TITLE
Don't render empty metadata sections on the collection show page.

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -29,6 +29,12 @@ module ArclightHelper
     facets_from_request.find { |f| f.name == 'collection_sim' }.try(:items).try(:count)
   end
 
+  def fields_have_content?(document, field_accessor)
+    generic_document_fields(field_accessor).any? do |_, field|
+      generic_should_render_field?(field_accessor, document, field)
+    end
+  end
+
   ##
   # Defines custom helpers used for creating unique metadata blocks to render
   Arclight::Engine.config.catalog_controller_field_accessors.each do |config_field|

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -5,6 +5,7 @@
   <div class='col-md-9'>
     <% unless blacklight_config.show.metadata_partials.nil? %>
       <% blacklight_config.show.metadata_partials.each do |metadata| %>
+        <% next unless fields_have_content?(@document, metadata) %>
         <%= render partial: 'custom_metadata', locals: { document: @document, field_accessor: metadata } %>
       <% end %>
     <% end %>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -15,6 +15,7 @@
       <ul class='nav nav-pills flex-column'>
         <% unless blacklight_config.show.metadata_partials.nil? %>
           <% blacklight_config.show.metadata_partials.each do |item| %>
+            <% next unless fields_have_content?(@document, item) %>
             <li class='nav-item'>
               <%= link_to t("arclight.views.show.sections.#{item}"), "##{t("arclight.views.show.sections.#{item}").parameterize}", class: 'nav-link' %>
             </li>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -115,6 +115,14 @@ RSpec.describe 'Collection Page', type: :feature do
         expect(page).to have_css('dd', text: /^Processed in 2001\. Descended from astronomers\./)
       end
     end
+
+    context 'sections that do not have metadata' do
+      let(:doc_id) { 'm0198-xml' }
+
+      it 'are not displayed' do
+        expect(page).not_to have_css('.al-show-sub-heading', text: 'Background')
+      end
+    end
   end
   describe 'navigation bar' do
     it 'has configured links' do
@@ -126,6 +134,17 @@ RSpec.describe 'Collection Page', type: :feature do
         expect(page).to have_css 'a[href="#administrative-information"]', text: 'Administrative Information'
       end
     end
+
+    context 'for sections that do not have metadata' do
+      let(:doc_id) { 'm0198-xml' }
+
+      it 'does not include links to those sections' do
+        within '.al-sidebar-navigation-overview' do
+          expect(page).not_to have_css 'a[href="#background"]', text: 'Background'
+        end
+      end
+    end
+
     describe 'context_sidebar' do
       it 'has a terms and conditions card' do
         within '#accordion' do

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -58,6 +58,32 @@ RSpec.describe ArclightHelper, type: :helper do
       it { expect(helper.collection_count).to be_nil }
     end
   end
+
+  describe '#fields_have_content?' do
+    before do
+      expect(helper).to receive_messages(
+        blacklight_config: CatalogController.blacklight_config,
+        blacklight_configuration_context: Blacklight::Configuration::Context.new(helper)
+      )
+    end
+
+    context 'when the configured fields have content' do
+      let(:document) { SolrDocument.new('acqinfo_ssm': ['Data']) }
+
+      it 'is true' do
+        expect(helper.fields_have_content?(document, :admin_info_field)).to eq true
+      end
+    end
+
+    context 'when the configured fields have no content' do
+      let(:document) { SolrDocument.new }
+
+      it 'is true' do
+        expect(helper.fields_have_content?(document, :admin_info_field)).to eq false
+      end
+    end
+  end
+
   describe '#parents_to_links' do
     let(:document) do
       SolrDocument.new(


### PR DESCRIPTION
Closes #208 

## Example m0198-xml

<img width="915" alt="m0198-xml" src="https://cloud.githubusercontent.com/assets/96776/25507459/0eec1b92-2b61-11e7-952d-4d1a281e0dce.png">
