### PR TITLE
Adjust elements for better visual design and accessibility

### DIFF
--- a/app/assets/stylesheets/arclight/application.scss
+++ b/app/assets/stylesheets/arclight/application.scss
@@ -1,2 +1,3 @@
+@import 'bootstrap/variables';
 @import 'modules/show_collection';
 @import 'modules/collection_search';

--- a/app/assets/stylesheets/arclight/modules/show_collection.scss
+++ b/app/assets/stylesheets/arclight/modules/show_collection.scss
@@ -1,4 +1,18 @@
 .al-sticky-sidebar {
   position: sticky;
   top: 0;
+
+  // Separate first-level divs in sidebar
+  > div {
+    margin-bottom: $spacer;
+  }
+
+  .card-header h3 {
+    font-size: $font-size-h6;
+    font-weight: 400;
+  }
+}
+
+.show-document h1 {
+  margin-bottom: $spacer * 2;
 }

--- a/app/views/catalog/_context_card.html.erb
+++ b/app/views/catalog/_context_card.html.erb
@@ -1,11 +1,11 @@
 <% doc_presenter = show_presenter(document) %>
 <div class="card">
   <div class="card-header" role="tab" id="heading<%= card_index %>">
-    <h5 class="mb-0">
+    <h3 class="mb-0">
       <a data-toggle="collapse" data-parent="#accordion" href="#collapse<%= card_index %>" aria-expanded="<%= card_index.zero? %>" aria-controls="collapse<%= card_index %>">
         <%= t("arclight.views.show.context_sidebar.#{field_accessor}") %>
       </a>
-    </h5>
+    </h3>
   </div>
 
   <div id="collapse<%= card_index %>" class="collapse <%= 'show' if card_index.zero? %>" role="tabpanel" aria-labelledby="heading<%= card_index %>">

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -3,6 +3,7 @@
     <%= render partial: 'show_sidebar' %>
   </div>
   <div class='col-md-9'>
+    <h2 class="sr-only">Collection description</h2>
     <% unless blacklight_config.show.metadata_partials.nil? %>
       <% blacklight_config.show.metadata_partials.each do |metadata| %>
         <% next unless fields_have_content?(@document, metadata) %>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,7 +1,8 @@
 <div class='al-sticky-sidebar'>
+  <h2 class="sr-only">Sidebar</h2>
   <div class='card'>
     <div class='card-header'>
-      Search within this collection
+      <h3 class="mb-0">Search within this collection</h3>
     </div>
     <div class='card-block'>
       <%= render 'search_within_form' %>
@@ -9,7 +10,7 @@
   </div>
   <div class='al-sidebar-navigation-overview card'>
     <div class='card-header'>
-      <%= t('arclight.views.show.navigation_sidebar.title') %>
+      <h3 class="mb-0"><%= t('arclight.views.show.navigation_sidebar.title') %></h3>
     </div>
     <div class='card-block'>
       <ul class='nav nav-pills flex-column'>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe 'Collection Page', type: :feature do
     describe 'context_sidebar' do
       it 'has a terms and conditions card' do
         within '#accordion' do
-          expect(page).to have_css '.card-header h5', text: 'Terms & Conditions'
+          expect(page).to have_css '.card-header h3', text: 'Terms & Conditions'
           expect(page).to have_css '.card-block dt', text: 'Restrictions:'
           expect(page).to have_css '.card-block dd', text: 'No restrictions on access.'
           expect(page).to have_css '.card-block dt', text: 'Terms of Access:'
@@ -158,7 +158,7 @@ RSpec.describe 'Collection Page', type: :feature do
 
       it 'has a how to cite card' do
         within '#accordion' do
-          expect(page).to have_css '.card-header h5', text: 'How to cite this collection'
+          expect(page).to have_css '.card-header h3', text: 'How to cite this collection'
           expect(page).to have_css '.card-block dt', text: 'Preferred citation'
           expect(page).to have_css '.card-block dd', text: /Omega Alpha Archives\. 1894-1992/
         end


### PR DESCRIPTION
This is just a first pass at some styling and accessibility updates. There's more to do, including a few contrast failures (possibly because of changes I made to the headings in the accordion) but I'll fix those soon in another PR.

* Added some screen-reader only headings to create a better (I think?) heading structure for the page, where the sidebar elements and the main content are nested separately, without skipping any heading levels
* Separated the sidebar sections evenly
* Made sidebar headings consistently sized

### Heading structure
![alpha_omega_alpha_archives__1894-1992_-_blacklight](https://cloud.githubusercontent.com/assets/101482/25508174/1b907a2e-2b65-11e7-81ca-8cfb6dfe28a7.png)

### Updated page
![alpha_omega_alpha_archives__1894-1992_-_blacklight 2](https://cloud.githubusercontent.com/assets/101482/25508181/23058bf0-2b65-11e7-9f19-4233850681f6.png)
