### PR TITLE
add facet items to collection summary

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,7 @@ Metrics/BlockLength:
     - 'arclight.gemspec'
     - 'spec/**/*'
     - 'tasks/**/*'
+    - 'lib/arclight/custom_document.rb'
 
 Performance/RegexpMatch:
   Enabled: false

--- a/lib/arclight/custom_document.rb
+++ b/lib/arclight/custom_document.rb
@@ -11,9 +11,13 @@ module Arclight
       t.unitid(path: 'archdesc/did/unitid', index_as: %i[displayable])
       t.repository(path: 'archdesc/did/repository/corpname/text() | archdesc/did/repository/name/text()', index_as: %i[displayable facetable])
       t.creator(path: "archdesc/did/origination[@label='creator']/*/text()", index_as: %i[displayable facetable symbol])
+      t.creator_persname(path: "archdesc/did/origination[@label='creator']/persname/text()", index_as: %i[displayable facetable symbol])
+      t.creator_corpname(path: "archdesc/did/origination[@label='creator']/corpname/text()", index_as: %i[displayable facetable symbol])
+      t.creator_famname(path: "archdesc/did/origination[@label='creator']/famname/text()", index_as: %i[displayable facetable symbol])
       t.prefercite(path: 'archdesc/prefercite/p', index_as: %i[displayable])
       t.function(path: 'archdesc/controlaccess/function/text()', index_as: %i[displayable facetable])
       t.occupation(path: 'archdesc/controlaccess/occupation/text()', index_as: %i[displayable facetable])
+      t.places(path: 'archdesc/controlaccess/geogname/text()', index_as: %i[displayable facetable symbol])
       t.otherfindaid(path: 'archdesc/otherfindaid/p', index_as: %i[displayable])
 
       # overrides of solr_ead to get different `index_as` properties
@@ -51,10 +55,10 @@ module Arclight
       [
         { name: 'level', value: 'collection', index_as: :displayable },
         { name: 'level', value: 'Collection', index_as: :facetable },
-        { name: 'names', value: names, index_as: :facetable },
+        { name: 'names', value: names, index_as: :symbol },
         { name: 'date_range', value: formatted_unitdate_for_range, index_as: :facetable },
-        { name: 'access_subjects', value: access_subjects, index_as: :facetable },
-        { name: 'all_subjects', value: all_subjects, index_as: :symbol },
+        { name: 'access_subjects', value: access_subjects, index_as: :symbol },
+        { name: 'creators', value: creators, index_as: :symbol },
         { name: 'has_online_content', value: online_content?, index_as: :displayable }
       ]
     end
@@ -63,17 +67,17 @@ module Arclight
       [corpname, famname, name, persname].flatten.compact.uniq - repository
     end
 
+    def creators
+      [creator_persname, creator_corpname, creator_famname].flatten.compact.uniq - repository
+    end
     # Combine subjets into one group from:
     #  <controlaccess/><subject></subject>
     #  <controlaccess/><function></function>
     #  <controlaccess/><genreform></genreform>
     #  <controlaccess/><occupation></occupation>
+
     def access_subjects
       subjects_array(%w[subject function occupation genreform], parent: 'archdesc')
-    end
-
-    def all_subjects
-      subjects_array(%w[corpname famname function genreform geogname occupation persname subject title], parent: 'archdesc')
     end
 
     def online_content?

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -72,14 +72,14 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'collection_sim', label: 'Collection'
     config.add_facet_field 'creator_ssim', label: 'Creator'
+    config.add_facet_field 'creators_ssim', label: 'Creator', show: false
     config.add_facet_field 'date_range_sim', label: 'Date range', range: true
     config.add_facet_field 'level_sim', label: 'Level'
-    config.add_facet_field 'names_sim', label: 'Names'
+    config.add_facet_field 'names_ssim', label: 'Names'
     config.add_facet_field 'repository_sim', label: 'Repository'
     config.add_facet_field 'geogname_sim', label: 'Place'
-    # Temp disable access_subjects_ssim for later revision
-    #config.add_facet_field 'access_subjects_ssim', label: 'Subject'
-    config.add_facet_field 'all_subjects_ssim', label: 'All Subjects'
+    config.add_facet_field 'places_ssim', label: 'Places', show:false
+    config.add_facet_field 'access_subjects_ssim', label: 'Subject'
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -168,7 +168,7 @@ class CatalogController < ApplicationController
     ]
 
     # Collection Show Page - Summary Section
-    config.add_summary_field 'creator_ssim', label: 'Creator', :link_to_facet => true
+    config.add_summary_field 'creators_ssim', label: 'Creator', :link_to_facet => true
     config.add_summary_field 'abstract_ssm', label: 'Abstract'
     config.add_summary_field 'extent_ssm', label: 'Extent'
     config.add_summary_field 'language_ssm', label: 'Language'
@@ -201,11 +201,28 @@ class CatalogController < ApplicationController
     config.add_related_field 'originalsloc_ssm', label: 'Location of originals'
 
     # Collection Show Page - Indexed Terms Section
-    config.add_indexed_terms_field 'all_subjects_ssim', label: 'Subjects', :link_to_facet => true, separator_options: {
+    config.add_indexed_terms_field 'access_subjects_ssim', label: 'Subjects', :link_to_facet => true, separator_options: {
       words_connector: '<br/>',
       two_words_connector: '<br/>',
       last_word_connector: '<br/>'
     }
+
+    config.add_indexed_terms_field 'names_ssim', label: 'Names', :link_to_facet => true, separator_options: {
+      words_connector: '<br/>',
+      two_words_connector: '<br/>',
+      last_word_connector: '<br/>'
+    }
+    config.add_indexed_terms_field 'places_ssim', label: 'Places', :link_to_facet => true, separator_options: {
+      words_connector: '<br/>',
+      two_words_connector: '<br/>',
+      last_word_connector: '<br/>'
+    }
+        
+    # Collection Show Page - Administrative Information Section
+    config.add_admin_info_field 'acqinfo_ssm', label: 'Acquisition information'
+    config.add_admin_info_field 'appraisal_ssm', label: 'Appraisal information'
+    config.add_admin_info_field 'custodhist_ssm', label: 'Custodial history'
+    config.add_admin_info_field 'processinfo_ssm', label: 'Processing information'
 
     config.show.partials.insert(0, :arclight_online_content_indicator)
     config.show.partials.insert(0, :arclight_document_header)

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -100,7 +100,14 @@ RSpec.describe 'Collection Page', type: :feature do
     it 'indexed terms has configured metadata' do
       within '#indexed-terms' do
         expect(page).to have_css('dt', text: 'Subjects')
+        expect(page).to have_css('dt', text: 'Names')
+        expect(page).to have_css('dt', text: 'Places')
         expect(page).to have_css('dd', text: 'Societies')
+        expect(page).to have_css('dd', text: 'Photographs')
+        expect(page).to have_css('dd', text: 'Medicine')
+        expect(page).to have_css('dd', text: 'Alpha Omega Alpha')
+        expect(page).to have_css('dd', text: 'Root, William Webster, 1867-1932')
+        expect(page).to have_css('dd', text: 'Bierring, Walter L. (Walter Lawrence), 1868-1961')
         expect(page).to have_css('dd', text: 'Mindanao Island (Philippines)')
       end
     end

--- a/spec/features/indexing_custom_document_spec.rb
+++ b/spec/features/indexing_custom_document_spec.rb
@@ -87,8 +87,7 @@ RSpec.describe 'Indexing Custom Document', type: :feature do
     end
 
     it '#creator' do
-      expect(doc['creator_ssm'].first).to eq 'Alpha Omega Alpha'
-      expect(doc['creator_sim'].first).to eq 'Alpha Omega Alpha'
+      expect(doc['creators_ssim'].first).to eq 'Alpha Omega Alpha'
     end
 
     it '#extent' do
@@ -107,20 +106,10 @@ RSpec.describe 'Indexing Custom Document', type: :feature do
       expect(doc['scopecontent_ssm'].first).to match(/^Correspondence, documents/)
     end
 
-    it '#names' do
-      expect(doc['names_sim']).to include 'Root, William Webster, 1867-1932'
-    end
-
-    it '#access_subjects' do
-      expect(doc['access_subjects_sim']).to include 'Fraternizing'
-    end
-
-    it '#all_subjects' do
-      subjects = doc['all_subjects_ssim']
-
-      expect(subjects.length).to eq 8
-      expect(subjects.first).to eq 'Societies'
-      expect(subjects.last).to eq 'Mindanao Island (Philippines)'
+    it '#indexed-terms' do
+      expect(doc['access_subjects_ssim']).to include 'Fraternizing'
+      expect(doc['names_ssim']).to include 'Root, William Webster, 1867-1932'
+      expect(doc['places_ssim']).to include 'Mindanao Island (Philippines)'
     end
 
     describe '#has_online_content' do

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Search resutls', type: :feature do
           expect(page).to have_css('.profile canvas.flot-base', visible: true)
         end
 
-        within('.blacklight-names_sim') do
+        within('.blacklight-names_ssim') do
           expect(page).to have_css('h3 a', text: 'Names')
           expect(page).to have_css('li .facet-label', text: 'Root, William Webster, 1867-1932', visible: false)
         end
@@ -92,8 +92,8 @@ RSpec.describe 'Search resutls', type: :feature do
           expect(page).to have_css('li .facet-label', text: 'Mindanao Island (Philippines)', visible: false)
         end
 
-        within('.blacklight-all_subjects_ssim') do
-          expect(page).to have_css('h3 a', text: 'All Subjects')
+        within('.blacklight-access_subjects_ssim') do
+          expect(page).to have_css('h3 a', text: 'Subject')
           expect(page).to have_css('li .facet-label', text: 'Societies', visible: false)
           expect(page).to have_css('li .facet-label', text: 'Fraternizing', visible: false)
           expect(page).to have_css('li .facet-label', text: 'Photographs', visible: false)


### PR DESCRIPTION
Still have one rubocop issue: In lib/arclight/custom_document.rb, the "  extend_terminology do |t|" block is too long. Two fixes I can think of:
1. Add file to .rubocop.yml in the "Metrics/BlockLength:   Exclude:" section.
2. Turn all calls with extend_terminology into a method that takes an array of terms, paths, and index_as elements.

Note: We only have one creator child, so it is hard to test that part.
Also, I still need to add rspec tests for this issue!
