### PR TITLE
Move metadata around on the collection page…

### DIFF
--- a/lib/arclight/engine.rb
+++ b/lib/arclight/engine.rb
@@ -14,13 +14,11 @@ module Arclight
       summary_field
       access_field
       background_field
-      scope_and_arrangement_field
       related_field
       admin_info_field
       terms_field
       cite_field
       indexed_terms_field
-      admin_info_field
     ]
 
     initializer 'arclight.fields' do

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -157,10 +157,8 @@ class CatalogController < ApplicationController
       :summary_field,
       :access_field,
       :background_field,
-      :scope_and_arrangement_field,
       :related_field,
       :indexed_terms_field,
-      :admin_info_field
     ]
 
     config.show.context_sidebar_items = [
@@ -187,11 +185,12 @@ class CatalogController < ApplicationController
     config.add_access_field 'userestrict_ssm', label: 'Terms Of Use'
 
     # Collection Show Page - Background Section
+    config.add_background_field 'scopecontent_ssm', label: 'Scope and Content'
     config.add_background_field 'bioghist_ssm', label: 'Biographical / Historical'
-
-    # Collection Show Page - Scope and Arrangement Section
-    config.add_scope_and_arrangement_field 'scopecontent_ssm', label: 'Scope and Content'
-    config.add_scope_and_arrangement_field 'arrangement_ssm', label: 'Arrangement'
+    config.add_background_field 'acqinfo_ssm', label: 'Acquisition information'
+    config.add_background_field 'appraisal_ssm', label: 'Appraisal information'
+    config.add_background_field 'custodhist_ssm', label: 'Custodial history'
+    config.add_background_field 'processinfo_ssm', label: 'Processing information'
 
     # Collection Show Page - Related Section
     config.add_related_field 'relatedmaterial_ssm', label: 'Related material'
@@ -206,12 +205,6 @@ class CatalogController < ApplicationController
       two_words_connector: '<br/>',
       last_word_connector: '<br/>'
     }
-
-    # Collection Show Page - Administrative Information Section
-    config.add_admin_info_field 'acqinfo_ssm', label: 'Acquisition information'
-    config.add_admin_info_field 'appraisal_ssm', label: 'Appraisal information'
-    config.add_admin_info_field 'custodhist_ssm', label: 'Custodial history'
-    config.add_admin_info_field 'processinfo_ssm', label: 'Processing information'
 
     config.show.partials.insert(0, :arclight_online_content_indicator)
     config.show.partials.insert(0, :arclight_document_header)

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -58,18 +58,23 @@ RSpec.describe 'Collection Page', type: :feature do
 
     it 'background has configured metadata' do
       within '#background' do
-        expect(page).to have_css('dt', text: 'Biographical / Historical')
-        expect(page).to have_css('dd', text: /^Alpha Omega Alpha Honor Medical Society was founded/)
-      end
-    end
-
-    it 'scope and arrangement has configured metadata' do
-      within '#scope-and-arrangement' do
         expect(page).to have_css('dt', text: 'Scope and Content')
         expect(page).to have_css('dd', text: /^Correspondence, documents, records, photos/)
 
-        expect(page).to have_css('dt', text: 'Arrangement')
-        expect(page).to have_css('dd', text: /^Arranged into seven series\./)
+        expect(page).to have_css('dt', text: 'Biographical / Historical')
+        expect(page).to have_css('dd', text: /^Alpha Omega Alpha Honor Medical Society was founded/)
+
+        expect(page).to have_css('dt', text: 'Acquisition information')
+        expect(page).to have_css('dd', text: 'Donated by Alpha Omega Alpha.')
+
+        expect(page).to have_css('dt', text: 'Appraisal information')
+        expect(page).to have_css('dd', text: /^Corpus callosum something incredible/)
+
+        expect(page).to have_css('dt', text: 'Custodial history')
+        expect(page).to have_css('dd', text: 'Maintained by Alpha Omega Alpha and the family of William Root.')
+
+        expect(page).to have_css('dt', text: 'Processing information')
+        expect(page).to have_css('dd', text: /^Processed in 2001\. Descended from astronomers\./)
       end
     end
 
@@ -100,27 +105,11 @@ RSpec.describe 'Collection Page', type: :feature do
       end
     end
 
-    it 'adminstrative information has configured metadata' do
-      within '#administrative-information' do
-        expect(page).to have_css('dt', text: 'Acquisition information')
-        expect(page).to have_css('dd', text: 'Donated by Alpha Omega Alpha.')
-
-        expect(page).to have_css('dt', text: 'Appraisal information')
-        expect(page).to have_css('dd', text: /^Corpus callosum something incredible/)
-
-        expect(page).to have_css('dt', text: 'Custodial history')
-        expect(page).to have_css('dd', text: 'Maintained by Alpha Omega Alpha and the family of William Root.')
-
-        expect(page).to have_css('dt', text: 'Processing information')
-        expect(page).to have_css('dd', text: /^Processed in 2001\. Descended from astronomers\./)
-      end
-    end
-
     context 'sections that do not have metadata' do
       let(:doc_id) { 'm0198-xml' }
 
       it 'are not displayed' do
-        expect(page).not_to have_css('.al-show-sub-heading', text: 'Background')
+        expect(page).not_to have_css('.al-show-sub-heading', text: 'Related')
       end
     end
   end
@@ -131,7 +120,7 @@ RSpec.describe 'Collection Page', type: :feature do
         expect(page).to have_css 'a[href="#access-and-use"]', text: 'Access and Use'
         expect(page).to have_css 'a[href="#background"]', text: 'Background'
         expect(page).to have_css 'a[href="#related"]', text: 'Related'
-        expect(page).to have_css 'a[href="#administrative-information"]', text: 'Administrative Information'
+        expect(page).to have_css 'a[href="#indexed-terms"]', text: 'Indexed Terms'
       end
     end
 
@@ -140,7 +129,7 @@ RSpec.describe 'Collection Page', type: :feature do
 
       it 'does not include links to those sections' do
         within '.al-sidebar-navigation-overview' do
-          expect(page).not_to have_css 'a[href="#background"]', text: 'Background'
+          expect(page).not_to have_css 'a[href="#related"]', text: 'Related'
         end
       end
     end

--- a/spec/features/collection_scrollspy_spec.rb
+++ b/spec/features/collection_scrollspy_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'Collection Scrollspy', type: :feature do
   end
   it 'as a user scrolls, active class is added', js: true do
     expect(page).to have_css '.al-sticky-sidebar'
-    expect(page).not_to have_css '.nav-link.active', text: 'Administrative Information'
+    expect(page).not_to have_css '.nav-link.active', text: 'Indexed Terms'
     page.driver.scroll_to(0, 10_000)
-    expect(page).to have_css '.nav-link.active', text: 'Administrative Information'
+    expect(page).to have_css '.nav-link.active', text: 'Indexed Terms'
   end
 end

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ArclightHelper, type: :helper do
       let(:document) { SolrDocument.new('acqinfo_ssm': ['Data']) }
 
       it 'is true' do
-        expect(helper.fields_have_content?(document, :admin_info_field)).to eq true
+        expect(helper.fields_have_content?(document, :background_field)).to eq true
       end
     end
 
@@ -79,7 +79,7 @@ RSpec.describe ArclightHelper, type: :helper do
       let(:document) { SolrDocument.new }
 
       it 'is true' do
-        expect(helper.fields_have_content?(document, :admin_info_field)).to eq false
+        expect(helper.fields_have_content?(document, :background_field)).to eq false
       end
     end
   end


### PR DESCRIPTION
…(removes Admin info and Scope and Arrangement sections).

Closes #215 

<img width="791" alt="collection-show" src="https://cloud.githubusercontent.com/assets/96776/25538744/c5295ac2-2bf8-11e7-9f89-6d85b77a144b.png">

