### PR TITLE
Don't render double commas in heading titles.

### DIFF
--- a/app/presenters/arclight/show_presenter.rb
+++ b/app/presenters/arclight/show_presenter.rb
@@ -5,9 +5,8 @@ module Arclight
   class ShowPresenter < Blacklight::ShowPresenter
     def heading
       title = super
-      date = document.fetch('unitdate_ssm', [])
-      title += ", #{date.first}" if date.present?
-      title
+      delimiter = heading_delimiter(title)
+      [title, document.unitdate].compact.join(delimiter)
     end
 
     def with_field_group(group)
@@ -25,6 +24,11 @@ module Arclight
 
     def field_config(field)
       BlacklightFieldConfigurationFactory.for(config: configuration, field: field, field_group: field_group)
+    end
+
+    def heading_delimiter(title)
+      return ', ' unless title.ends_with?(',')
+      ' '
     end
   end
 end

--- a/spec/presenters/arclight/show_presenter_spec.rb
+++ b/spec/presenters/arclight/show_presenter_spec.rb
@@ -24,9 +24,25 @@ describe Arclight::ShowPresenter, type: :presenter do
     it 'appends the date' do
       expect(presenter.heading).to eq 'My Title, 1900-2000'
     end
-    it 'handles missing date' do
-      allow(document).to receive(:fetch).with('unitdate_ssm', []).and_return(nil)
-      expect(presenter.heading).to eq 'My Title'
+
+    context 'documents without dates' do
+      let(:document) { SolrDocument.new(id: 1, 'title_ssm' => ['My Title']) }
+
+      it 'only renders the title' do
+        expect(presenter.heading).to eq 'My Title'
+      end
+    end
+
+    context 'titles with commas' do
+      let(:document) do
+        SolrDocument.new(id: 1,
+                         'title_ssm' => ['My Title,'],
+                         'unitdate_ssm' => ['1900-2000'])
+      end
+
+      it 'does not duplicate commas' do
+        expect(presenter.heading).to eq 'My Title, 1900-2000'
+      end
     end
   end
 


### PR DESCRIPTION
Closes #180 

# Before
<img width="859" alt="before" src="https://cloud.githubusercontent.com/assets/96776/25543102/08288814-2c0a-11e7-8274-83be6b768b2e.png">

# After
<img width="876" alt="after" src="https://cloud.githubusercontent.com/assets/96776/25543103/0836b7c2-2c0a-11e7-9ad1-a94142ef10e6.png">
