### PR TITLE
Override Blacklight's show_header partial…

### DIFF
--- a/app/views/catalog/_show_header.html.erb
+++ b/app/views/catalog/_show_header.html.erb
@@ -1,0 +1,5 @@
+<div class='al-show-header-section'>
+  <%= render_document_partial(document, 'arclight_document_show_header') %>
+  <%= render_document_partial(document, 'arclight_online_content_indicator') %>
+  <%= render_document_heading(document, :tag => :h1) %>
+</div>

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -217,15 +217,12 @@ class CatalogController < ApplicationController
       two_words_connector: '<br/>',
       last_word_connector: '<br/>'
     }
-        
+
     # Collection Show Page - Administrative Information Section
     config.add_admin_info_field 'acqinfo_ssm', label: 'Acquisition information'
     config.add_admin_info_field 'appraisal_ssm', label: 'Appraisal information'
     config.add_admin_info_field 'custodhist_ssm', label: 'Custodial history'
     config.add_admin_info_field 'processinfo_ssm', label: 'Processing information'
-
-    config.show.partials.insert(0, :arclight_online_content_indicator)
-    config.show.partials.insert(0, :arclight_document_show_header)
 
     # Remove unused show document actions
     %i[citation email sms].each do |action|


### PR DESCRIPTION
… and manually render title bar and online-content indicator in order to get a wrapping div around all these elements.

This was requested by @ggeisler to facilitate styling the show page.

<img width="1229" alt="show-header" src="https://cloud.githubusercontent.com/assets/96776/25686988/77576266-3027-11e7-8757-ce4c46b06159.png">
