### PR TITLE
Add direct child component count to content inventory

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -36,3 +36,9 @@
     }
   }
 }
+
+.documents-hierarchy {
+  .al-number-of-children-badge {
+    margin-left: $spacer * 2;
+  }
+}

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -53,5 +53,9 @@ module Arclight
     def online_content?
       first('has_online_content_ssm') == 'true'
     end
+
+    def number_of_children
+      first('child_component_count_isim') || 0
+    end
   end
 end

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -1,0 +1,10 @@
+<header class="documentHeader row">
+  <h3 class="index_title document-title-heading col-md-12">
+    <% counter = document_counter_with_offset(document_counter) %>
+    <%= link_to_document document, document_show_link_field(document), counter: counter %>
+
+    <span class='badge badge-default al-number-of-children-badge'>
+      <%= t(:'arclight.views.index.number_of_children', count: document.number_of_children) %>
+    </span>
+  </h3>
+</header>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -8,6 +8,10 @@ en:
       home:
         heading: 'Archival Collections at Institution'
       index:
+        number_of_children:
+          zero: 'No children'
+          one: '1 child'
+          other: '%{count} children'
         collection_search:
           count: 'collection'
       online_content_indicator: 'online content'

--- a/lib/arclight/solr_ead_indexer_ext.rb
+++ b/lib/arclight/solr_ead_indexer_ext.rb
@@ -10,6 +10,8 @@ module Arclight
 
       add_collection_context_to_parent_fields(node, solr_doc)
 
+      add_count_of_child_compontents(node, solr_doc)
+
       solr_doc
     end
 
@@ -39,6 +41,10 @@ module Arclight
 
       solr_doc[parent_titles_field_name] = (solr_doc[parent_titles_field_name] || []).unshift(eadtitle)
       solr_doc[parent_titles_search_field_name] = (solr_doc[parent_titles_search_field_name] || []).unshift(eadtitle)
+    end
+
+    def add_count_of_child_compontents(node, solr_doc)
+      solr_doc[Solrizer.solr_name('child_component_count', type: :integer)] = node.xpath('count(c)').to_i
     end
   end
 end

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -193,6 +193,7 @@
          score,
          abstract_ssm,
          accessrestrict_ssm,
+         child_component_count_isim,
          collection_ssm,
          creator_ssm,
          extent_ssm,

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -200,6 +200,13 @@ RSpec.describe 'Collection Page', type: :feature do
         end
         expect(page).to have_css '.show-document', text: /Series I: Administrative Records/
       end
+
+      it 'includes the number of direct children of the component' do
+        within '.document-position-0' do
+          expect(page).to have_css('.document-title-heading .al-number-of-children-badge', text: '25 children')
+        end
+      end
+
       it 'clicking contents does not change the session results view context' do
         visit search_catalog_path q: '', search_field: 'all_fields'
 

--- a/spec/lib/arclight/indexer_spec.rb
+++ b/spec/lib/arclight/indexer_spec.rb
@@ -29,4 +29,18 @@ RSpec.describe Arclight::Indexer do
       end
     end
   end
+
+  describe '#add_count_of_child_compontents' do
+    it 'adds the number of direct children' do
+      node = xml.xpath('//c[@id="aspace_563a320bb37d24a9e1e6f7bf95b52671"]').first
+      fields = indexer.additional_component_fields(node)
+      expect(fields['child_component_count_isim']).to eq 25
+    end
+
+    it 'retunrs zero when the child has no components' do
+      node = xml.xpath('//c[@id="aspace_843e8f9f22bac69872d0802d6fffbb04"]').first
+      fields = indexer.additional_component_fields(node)
+      expect(fields['child_component_count_isim']).to eq 0
+    end
+  end
 end


### PR DESCRIPTION
Closes #189 


<img width="1181" alt="collection-contents" src="https://cloud.githubusercontent.com/assets/96776/25725920/ce6aa7fc-30d6-11e7-915d-2dc88674db49.png">

_**Note:** This change didn't introduce that breadcrumb, we're just seeing it for the first time now because the top-level components never had a breadcrumb before #261.  Not sure if @mejackreed is looking into this issue for the multi-level hierarchy work he's doing (which should also surface this issue)._