### PR TITLE
Safe join the title and date for document titles/labels.

### DIFF
--- a/app/presenters/arclight/index_presenter.rb
+++ b/app/presenters/arclight/index_presenter.rb
@@ -6,7 +6,7 @@ module Arclight
     def label(*)
       title = super
       delimiter = heading_delimiter(title)
-      [title, document.unitdate].compact.join(delimiter)
+      view_context.safe_join([title, document.unitdate].compact, delimiter)
     end
 
     private

--- a/app/presenters/arclight/show_presenter.rb
+++ b/app/presenters/arclight/show_presenter.rb
@@ -6,7 +6,7 @@ module Arclight
     def heading
       title = super
       delimiter = heading_delimiter(title)
-      [title, document.unitdate].compact.join(delimiter)
+      view_context.safe_join([title, document.unitdate].compact, delimiter)
     end
 
     def with_field_group(group)

--- a/spec/features/compontent_page_spec.rb
+++ b/spec/features/compontent_page_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Collection Page', type: :feature do
+  let(:doc_id) { 'aoa271aspace_843e8f9f22bac872d0802d6fffbb04' }
+
+  before { visit solr_document_path(id: doc_id) }
+
+  describe 'label/title' do
+    it 'does not double escape entities in the heading' do
+      expect(page).to have_css('h1', text: /^"A brief account of the origin of/)
+      expect(page).not_to have_css('h1', text: /^&quot;A brief account of the origin of/)
+    end
+  end
+end

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe 'Search results', type: :feature do
       expect(page).not_to have_css('.document-counter')
     end
 
+    it 'does not double escape entities in the heading' do
+      visit search_catalog_path q: '', search_field: 'all_fields'
+      expect(page).to have_css(
+        'h3.index_title',
+        text: '"A brief account of the origin of the Alpha Omega Alpha Honorary Fraternity" - William W. Root, n.d.'
+      )
+      expect(page).not_to have_css(
+        'h3.index_title',
+        text: /&quote;A brief account of the origin/
+      )
+    end
+
     # Very little metadata exists at the component level to drive any tests
     it 'renders metadata to meet minumum DACS requirements for a component'
 

--- a/spec/presenters/arclight/index_presenter_spec.rb
+++ b/spec/presenters/arclight/index_presenter_spec.rb
@@ -5,10 +5,11 @@ require 'spec_helper'
 describe Arclight::IndexPresenter, type: :presenter do
   subject { presenter }
 
-  let(:request_context) { instance_double('Context', document_index_view_type: 'index') }
+  let(:view_context) { ActionView::Base.new }
+
   let(:config) { Blacklight::Configuration.new }
 
-  let(:presenter) { described_class.new(document, request_context, config) }
+  let(:presenter) { described_class.new(document, view_context, config) }
 
   let(:document) do
     SolrDocument.new(id: 1,
@@ -17,6 +18,10 @@ describe Arclight::IndexPresenter, type: :presenter do
   end
 
   before do
+    expect(view_context).to receive_messages(
+      controller: instance_double('Controller', params: {}, session: {}),
+      default_document_index_view_type: 'index'
+    )
     config.index.title_field = :title_ssm
   end
 

--- a/spec/presenters/arclight/show_presenter_spec.rb
+++ b/spec/presenters/arclight/show_presenter_spec.rb
@@ -5,10 +5,10 @@ require 'spec_helper'
 describe Arclight::ShowPresenter, type: :presenter do
   subject { presenter }
 
-  let(:request_context) { double }
+  let(:view_context) { ActionView::Base.new }
   let(:config) { Blacklight::Configuration.new }
 
-  let(:presenter) { described_class.new(document, request_context, config) }
+  let(:presenter) { described_class.new(document, view_context, config) }
 
   let(:document) do
     SolrDocument.new(id: 1,


### PR DESCRIPTION
Fixes #235 

## In search results
<img width="859" alt="search-results" src="https://cloud.githubusercontent.com/assets/96776/25765902/4805ad6e-31a4-11e7-8ec9-3f18af2a9cb2.png">

## On the record view
<img width="1184" alt="component-record-view" src="https://cloud.githubusercontent.com/assets/96776/25765901/4804b846-31a4-11e7-88a7-107ef949c4c1.png">
