### PR TITLE
Update sidebar styling to better accommodate 'In person' section

### DIFF
--- a/app/assets/stylesheets/arclight/modules/show_collection.scss
+++ b/app/assets/stylesheets/arclight/modules/show_collection.scss
@@ -10,7 +10,37 @@
 
   .card-header h3 {
     font-size: $font-size-h6;
-    font-weight: 400;
+    font-weight: $font-weight-normal;
+  }
+
+  // Sidebar sections
+  dt {
+    color: $gray;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-bold;
+    margin-bottom: 3px;
+    text-transform: uppercase;
+  }
+
+  dd {
+    margin-bottom: $spacer;
+  }
+
+  .al-in-person-repository-name,
+  .al-in-person-repository-location {
+    font-size: $font-size-sm;
+    line-height: 1.25;
+  }
+
+  .al-in-person-repository-name img {
+    margin-bottom: $headings-margin-bottom;
+    margin-right: $spacer;
+    max-height: 65px;
+    max-width: 65px;
+  }
+
+  .al-repository-contact-city_state_zip_country {
+    margin-bottom: ($spacer / 2);
   }
 }
 


### PR DESCRIPTION
* Add styling for location information info
* Update styling of headers within each sidebar section

(I'll likely reorganize the SCSS to after there is a PR for the component sidebar, to make things less collection-specific.)

Examples:

![alpha_omega_alpha_archives__1894-1992_-_blacklight](https://cloud.githubusercontent.com/assets/101482/25810778/07d76254-33c6-11e7-86dc-8699fa971ab0.png)


---

![the_italian_or_the_confessional_of_the_black_penitents___typescript__1930_-_blacklight](https://cloud.githubusercontent.com/assets/101482/25810793/0cbaa042-33c6-11e7-8989-0162298f7fb3.png)


---

![alpha_omega_alpha_archives__1894-1992_-_blacklight 2](https://cloud.githubusercontent.com/assets/101482/25810797/112b426c-33c6-11e7-85ae-5f9787ee73ff.png)
