### PR TITLE
Update home masthead and add masthead to other pages

### DIFF
--- a/app/assets/stylesheets/arclight/application.scss
+++ b/app/assets/stylesheets/arclight/application.scss
@@ -1,10 +1,11 @@
 @import 'bootstrap/variables';
 @import 'bootstrap_overrides';
 @import 'variables';
-@import 'modules/layout';
-@import 'modules/show_collection';
-@import 'modules/repository_card.scss';
 @import 'modules/collection_search';
-@import 'modules/search_results';
 @import 'modules/hierarchy';
+@import 'modules/layout';
+@import 'modules/mastheads';
+@import 'modules/repository_card.scss';
+@import 'modules/search_results';
+@import 'modules/show_collection';
 @import 'modules/sidebar';

--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -39,5 +39,17 @@
     .active a {
       color: $gray;
     }
+
+    // TODO: remove this after figuring out why the default toggler icon is not displaying
+    .navbar-toggler {
+      background: #ccc;
+    }
+  }
+
+  @media (max-width: 992px) {
+    h1,
+    + .navbar-search {
+      text-align: center;
+    }
   }
 }

--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -1,0 +1,21 @@
+.al-homepage.jumbotron {
+  border-bottom: $result-item-border-styling;
+  padding: ($spacer * 2) $spacer $spacer;
+
+  h1 {
+    font-size: 2.25rem;
+    margin-bottom: ($spacer * 2);
+  }
+
+  .search-query-form {
+    margin-bottom: $spacer;
+  }
+
+  .navbar {
+    padding-bottom: 0;
+    
+    a {
+      font-weight: $font-weight-bold;
+    }
+  }
+}

--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -1,4 +1,4 @@
-.al-homepage.jumbotron {
+.al-homepage-masthead.jumbotron {
   border-bottom: $result-item-border-styling;
   padding: ($spacer * 2) $spacer $spacer;
 
@@ -13,9 +13,31 @@
 
   .navbar {
     padding-bottom: 0;
-    
+
     a {
       font-weight: $font-weight-bold;
+    }
+  }
+}
+
+.al-masthead {
+  h1 {
+    font-size: $font-size-h2;
+    margin: 0;
+    padding: ($spacer * 1.5) ($spacer / 2);
+  }
+
+  + .navbar-search {
+    border-bottom: $result-item-border-styling;
+    border-top: $result-item-border-styling;
+    margin-bottom: ($spacer / 2);
+
+    a {
+      font-weight: $font-weight-bold;
+    }
+
+    .active a {
+      color: $gray;
     }
   }
 }

--- a/app/views/catalog/_home.html.erb
+++ b/app/views/catalog/_home.html.erb
@@ -1,11 +1,1 @@
-<div class='jumbotron'>
-  <div class='row'>
-    <div class='col-md-8 offset-md-2'>
-      <h1 class='text-center'><%= t('arclight.views.home.heading') %></h1>
-    </div>
-  </div>
-  <div class='row'>
-    <div class='col-md-6 offset-md-3'>
-        <%= render_search_bar %>
-    </div>
-</div>
+

--- a/app/views/catalog/_search_within_form.html.erb
+++ b/app/views/catalog/_search_within_form.html.erb
@@ -4,7 +4,7 @@
     <%= hidden_field_tag :search_field, search_fields.first.last %>
     <%= hidden_field_tag :search_field, 'within_collection' %>
 
-    <label for='q' class='sr-only'><%= t('blacklight.search.form.search.label') %></label>
+    <label for='q' class='sr-only'><%= t('arclight.views.show.search_within') %></label>
     <%= text_field_tag :q, params[:q], class: 'search_q q form-control', id: 'q', autofocus: should_autofocus_on_search_box? %>
 
     <span class='input-group-btn'>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -13,10 +13,10 @@
 </nav>
 
 <% if controller_name == 'catalog' && !has_search_parameters? && action_name == 'index' %>
-  <div class='al-homepage jumbotron'>
+  <div class='al-homepage-masthead jumbotron'>
     <div class='row'>
       <div class='col-md-8 offset-md-2'>
-        <h1 class='text-center'><%= t('arclight.views.home.heading') %></h1>
+        <h1 class='text-center'><%= t('arclight.masthead_heading') %></h1>
       </div>
     </div>
     <div class='row'>
@@ -31,7 +31,14 @@
     </nav>
   </div>
 <% else %>
-  <div class="navbar-search navbar navbar-light navbar-toggleable-md bg-faded" role="navigation">
+  <div class='row bg-faded al-masthead'>
+    <div class='col'>
+      <div class="container">
+        <h1><%= t('arclight.masthead_heading') %></h1>
+      </div>
+    </div>
+  </div>
+  <div class="navbar-search navbar navbar-toggleable-md bg-faded" role="navigation">
     <div class="<%= container_classes %>">
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav mr-auto">

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -38,8 +38,11 @@
       </div>
     </div>
   </div>
-  <div class="navbar-search navbar navbar-toggleable-md bg-faded" role="navigation">
+  <div class="navbar-search navbar navbar-toggleable-sm bg-faded" role="navigation">
     <div class="<%= container_classes %>">
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav mr-auto">
           <%= render 'shared/main_menu_links' %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -13,7 +13,7 @@
 </nav>
 
 <% if controller_name == 'catalog' && !has_search_parameters? && action_name == 'index' %>
-  <div class='jumbotron'>
+  <div class='al-homepage jumbotron'>
     <div class='row'>
       <div class='col-md-8 offset-md-2'>
         <h1 class='text-center'><%= t('arclight.views.home.heading') %></h1>
@@ -24,18 +24,18 @@
         <%= render_search_bar %>
       </div>
     </div>
+    <nav class="navbar" role="navigation">
+      <ul class="nav justify-content-center">
+        <%= render 'shared/main_menu_links' %>
+      </ul>
+    </nav>
   </div>
 <% else %>
   <div class="navbar-search navbar navbar-light navbar-toggleable-md bg-faded" role="navigation">
     <div class="<%= container_classes %>">
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav mr-auto">
-          <li class="nav-item <%= repositories_active_class %>">
-            <%= link_to t('arclight.routes.repositories'), arclight_engine.repositories_path, class: 'nav-link' %>
-          </li>
-          <li class="nav-item <%= collection_active_class %>">
-            <%= link_to t('arclight.routes.collections'), arclight_engine.collections_path, class: 'nav-link' %>
-          </li>
+          <%= render 'shared/main_menu_links' %>
         </ul>
         <%= render_search_bar  %>
       </div>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -12,7 +12,20 @@
   </div>
 </nav>
 
-<% if (controller_name == 'catalog' && has_search_parameters?) || controller_name == 'repositories' %>
+<% if controller_name == 'catalog' && !has_search_parameters? && action_name == 'index' %>
+  <div class='jumbotron'>
+    <div class='row'>
+      <div class='col-md-8 offset-md-2'>
+        <h1 class='text-center'><%= t('arclight.views.home.heading') %></h1>
+      </div>
+    </div>
+    <div class='row'>
+      <div class='col-md-6 offset-md-3'>
+        <%= render_search_bar %>
+      </div>
+    </div>
+  </div>
+<% else %>
   <div class="navbar-search navbar navbar-light navbar-toggleable-md bg-faded" role="navigation">
     <div class="<%= container_classes %>">
       <div class="collapse navbar-collapse" id="navbarSupportedContent">

--- a/app/views/shared/_main_menu_links.html.erb
+++ b/app/views/shared/_main_menu_links.html.erb
@@ -1,0 +1,6 @@
+<li class="nav-item <%= repositories_active_class %>">
+  <%= link_to t('arclight.routes.repositories'), arclight_engine.repositories_path, class: 'nav-link' %>
+</li>
+<li class="nav-item <%= collection_active_class %>">
+  <%= link_to t('arclight.routes.collections'), arclight_engine.collections_path, class: 'nav-link' %>
+</li>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -1,5 +1,6 @@
 en:
   arclight:
+    masthead_heading: 'Archival Collections at Institution'
     hierarchy:
       view_more: 'View more'
     routes:
@@ -8,8 +9,6 @@ en:
       repositories: 'Repositories'
       search_results: 'Search results'
     views:
-      home:
-        heading: 'Archival Collections at Institution'
       index:
         number_of_children:
           zero: 'No children'
@@ -22,6 +21,7 @@ en:
         collection_id: 'Collection ID: %{id}'
         overview: 'Overview'
         no_contents: 'No content inventory'
+        search_within: 'Search within this collection'
         navigation_sidebar:
           title: 'Navigation overview'
         context_sidebar:

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -179,14 +179,18 @@ RSpec.describe 'Collection Page', type: :feature do
 
   describe 'search within' do
     it 'has only items from this collection' do
-      click_button 'search'
+      within('.al-sticky-sidebar') do
+        click_button 'Search'
+      end
       within '#facet-collection_sim' do
         expect(page).to have_css 'li', count: 1
       end
     end
 
     it 'does not include the collection record' do
-      click_button 'search'
+      within('.al-sticky-sidebar') do
+        click_button 'Search'
+      end
 
       expect(page).not_to have_css('h3.index_title', text: /Alpha Omega Alpha Archives/)
       expect(page).to have_css('.page-entries', text: '1 - 10 of 35')


### PR DESCRIPTION
Fixes #297.

One TODO noted in the `mastheads.scss` file is to figure out why the toggler icon from Bootstrap is not (seemingly) being loaded in the masthead, although it is in the topbar. This is pretty minor and I'll figure it out when improving other responsive issues.

Examples:

### Home, updated
![blacklight 2](https://cloud.githubusercontent.com/assets/101482/25876550/c1afc56a-34d2-11e7-8620-1fa7c299a278.png)
---
### Repositories
![blacklight](https://cloud.githubusercontent.com/assets/101482/25876537/b91bf072-34d2-11e7-9e27-bca728080a54.png)

---
### Search result
![within_collection__material___collection__alpha_omega_alpha_archives_-_blacklight_search_results](https://cloud.githubusercontent.com/assets/101482/25876551/c4c65e08-34d2-11e7-952f-fbd3ab2016cc.png)
---
### Mobile
![-_blacklight_search_results](https://cloud.githubusercontent.com/assets/101482/25876549/be1e5f24-34d2-11e7-86a1-2aeb24626b7f.png)