### PR TITLE
warn if EAD has unitdates with multiple date ranges

### DIFF
--- a/lib/arclight/shared_indexing_behavior.rb
+++ b/lib/arclight/shared_indexing_behavior.rb
@@ -5,14 +5,33 @@ module Arclight
   # A mixin intended to share indexing behavior between
   # the CustomDocument and CustomComponent classes
   module SharedIndexingBehavior
+    # TODO: probably should have a proper DateRange class at some point
+    def to_year_from_iso8601(date)
+      return if date.blank?
+      date.split('-').first[0..3].to_i
+    end
+
+    # @param [String] `dates` YYYY or YYYY/YYYY formats, including YYYY-MM, YYYY-MM-DD, and YYYYMMDD
+    # @return [Array<String>] all of the years between the given years
+    # TODO: probably should have a proper DateRange class at some point
+    def to_date_range(dates)
+      return if dates.blank?
+      start_year, end_year = dates.split('/').map { |date| to_year_from_iso8601(date) }
+
+      return [start_year.to_s] if end_year.nil?
+      raise "Unsupported date formats: #{dates}" if (end_year - start_year).abs > 2100
+      (start_year..end_year).to_a.map(&:to_s)
+    end
+
     # @see http://eadiva.com/2/unitdate/
-    # Currently only handling normal attributes and YYYY or YYYY/YYYY formats
+    # @return [Array<String>] all of the years between the given years
     def formatted_unitdate_for_range
       return if normal_unit_dates.blank?
-      normal_unit_date = Array.wrap(normal_unit_dates).first
-      start_date, end_date = normal_unit_date.split('/')
-      return [start_date] if end_date.blank?
-      (start_date..end_date).to_a
+
+      all_dates = Array.wrap(normal_unit_dates)
+      puts "WARNING: Unsupported multi-date data: #{normal_unit_dates}" if all_dates.length > 1 # rubocop: disable Rails/Output, Metrics/LineLength
+
+      to_date_range(all_dates.first)
     end
 
     def subjects_array(elements, parent:)

--- a/spec/lib/arclight/shared_indexing_behavior_spec.rb
+++ b/spec/lib/arclight/shared_indexing_behavior_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+class TestClass
+  attr_accessor :normal_unit_dates
+  include Arclight::SharedIndexingBehavior
+end
+
+RSpec.describe Arclight::SharedIndexingBehavior do
+  subject(:indexer) { TestClass.new }
+
+  context '#to_year_from_iso8601' do
+    it 'blanks' do
+      expect(indexer.to_year_from_iso8601(nil)).to be_nil
+      expect(indexer.to_year_from_iso8601('   ')).to be_nil
+    end
+    it 'YYYY' do
+      expect(indexer.to_year_from_iso8601('1999')).to eq 1999
+    end
+    it 'YYYY-MM' do
+      expect(indexer.to_year_from_iso8601('1999-01')).to eq 1999
+    end
+    it 'YYYY-MM-DD' do
+      expect(indexer.to_year_from_iso8601('1999-01-02')).to eq 1999
+    end
+    it 'YYYYMMDD' do
+      expect(indexer.to_year_from_iso8601('19990102')).to eq 1999
+    end
+    it 'tiny years' do
+      expect(indexer.to_year_from_iso8601('1')).to eq 1
+    end
+  end
+
+  context '#to_date_range' do
+    it 'blanks' do
+      expect(indexer.to_date_range(nil)).to be_nil
+      expect(indexer.to_date_range('   ')).to be_nil
+    end
+    it 'YYYY' do
+      expect(indexer.to_date_range('1999')).to eq %w[1999]
+    end
+    it 'YYYY/YYYY' do
+      expect(indexer.to_date_range('1999/2000')).to eq %w[1999 2000]
+    end
+    it 'too large YYYY/YYYY' do
+      expect { indexer.to_date_range('1999/9999') }.to raise_error(RuntimeError, /unsupported/i)
+    end
+    it 'YYYY-MM/YYYY' do
+      expect(indexer.to_date_range('1999-12/2000')).to eq %w[1999 2000]
+    end
+    it 'YYYY-MM-DD/YYYY' do
+      expect(indexer.to_date_range('1999-12-31/2000')).to eq %w[1999 2000]
+    end
+    it 'YYYYMMDD/YYYY' do
+      expect(indexer.to_date_range('19991231/2000')).to eq %w[1999 2000]
+    end
+  end
+
+  context '#formatted_unitdate_for_range' do
+    it 'single range' do
+      indexer.normal_unit_dates = %w[1999/2000]
+      expect(indexer.formatted_unitdate_for_range).to eq %w[1999 2000]
+    end
+    it 'multiple ranges will warn and only pick first' do
+      indexer.normal_unit_dates = %w[1999/2000 2010/2011]
+      expect($stdout).to receive(:puts).with(/warning.*unsupported/i) # rubocop: disable RSpec/MessageSpies
+      expect(indexer.formatted_unitdate_for_range).to eq %w[1999 2000]
+    end
+    it 'bogus call' do
+      indexer.normal_unit_dates = %w[]
+      expect(indexer.formatted_unitdate_for_range).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Related to #267 and #306. The PR fixes a problem where the indexer would stall and not finish with EADs with more complicated dates than YYYY or YYYY/YYYY. This piece of code is for the blacklight range limit data -- it has to generate year ranges for the facet (e.g., 1999/2001 --> 1999, 2000, 2001). The specs support some of the formats in #306.

This PR just causes the indexer to output a warning if we have multiple date ranges, and it takes the first date range. I decided to just have the warning and pick the first one for now so we can index the EADs that have the ranges right now as-is, and #305 will correct this problem.

Example output:

```
Loading spec/fixtures/ead/umich-bhl-0047.xml into index...
WARNING: Unsupported multi-date data: ["1910/2000", "1997/2000"]
Indexed spec/fixtures/ead/umich-bhl-0047.xml (in 0.481 secs).
```