### PR TITLE
Improve appearance of main menu toggler icon

### DIFF
--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -40,9 +40,13 @@
       color: $gray;
     }
 
-    // TODO: remove this after figuring out why the default toggler icon is not displaying
     .navbar-toggler {
-      background: #ccc;
+      background-color: $white;
+      border: $result-item-border-styling;
+    }
+
+    .navbar-toggler-icon {
+      background-image: $navbar-light-toggler-bg;
     }
   }
 


### PR DESCRIPTION
Now looks like this:

![alpha_omega_alpha_archives__1894-1992_-_blacklight](https://cloud.githubusercontent.com/assets/101482/25909895/6bcbb33e-3563-11e7-9bc0-b1d55bff697e.png)
