### PR TITLE
support for gaps in multiple year ranges, such as 1999/2002, 2004/2005

### DIFF
--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -40,7 +40,9 @@ module Arclight
     end
 
     def unitdate
-      first('unitdate_ssm')
+      date = fetch('unitdate_ssm', []).join(', ')
+      return if date.blank?
+      date
     end
 
     def extent

--- a/lib/arclight.rb
+++ b/lib/arclight.rb
@@ -3,6 +3,7 @@
 require 'arclight/version'
 require 'arclight/engine'
 require 'arclight/repository'
+require 'arclight/year_range'
 
 module Arclight
   # Your code goes here...

--- a/lib/arclight/custom_component.rb
+++ b/lib/arclight/custom_component.rb
@@ -26,9 +26,9 @@ module Arclight
       super
       solr_doc['id'] = Arclight::NormalizedId.new(solr_doc['id']).to_s
       Solrizer.insert_field(solr_doc, 'level', formatted_level, :facetable) # human-readable for facet `level_sim`
-      Solrizer.insert_field(solr_doc, 'date_range', formatted_unitdate_for_range, :facetable)
       Solrizer.insert_field(solr_doc, 'access_subjects', access_subjects, :facetable)
       Solrizer.insert_field(solr_doc, 'containers', containers, :symbol)
+      add_date_ranges(solr_doc)
       resolve_repository(solr_doc)
       add_digital_content(prefix: 'c/did', solr_doc: solr_doc)
 

--- a/lib/arclight/custom_document.rb
+++ b/lib/arclight/custom_document.rb
@@ -48,6 +48,7 @@ module Arclight
         Solrizer.set_field(solr_doc, field[:name], field[:value], field[:index_as])
       end
 
+      add_date_ranges(solr_doc)
       add_digital_content(prefix: 'ead/archdesc', solr_doc: solr_doc)
 
       solr_doc
@@ -55,13 +56,11 @@ module Arclight
 
     private
 
-    # rubocop: disable Metrics/MethodLength
     def arclight_field_definitions
       [
         { name: 'level', value: 'collection', index_as: :displayable },
         { name: 'level', value: 'Collection', index_as: :facetable },
         { name: 'names', value: names, index_as: :symbol },
-        { name: 'date_range', value: formatted_unitdate_for_range, index_as: :facetable },
         { name: 'access_subjects', value: access_subjects, index_as: :symbol },
         { name: 'creators', value: creators, index_as: :symbol },
         { name: 'has_online_content', value: online_content?, index_as: :displayable },

--- a/lib/arclight/year_range.rb
+++ b/lib/arclight/year_range.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Arclight
+  # A range of years that handles gaps, such as [1999, 2000, 2002].
+  # Primary usage is:
+  # ```
+  # range = YearRange.new('1999/2004')
+  # range.years => [1999, 2000, 2001, 2002, 2003, 2004]
+  # range.to_s => '1999-2004'
+  # range << range.parse_ranges(['2010/2010'])
+  # range.years => [1999, 2000, 2001, 2002, 2003, 2004, 2010]
+  # range.to_s => '1999-2004, 2010'
+  # ```
+  class YearRange
+    attr_accessor :years
+
+    # @param [Array<String>] `dates` in the form YYYY/YYYY
+    def initialize(dates = nil)
+      @years = []
+      self << parse_ranges(dates) if dates.present?
+      self
+    end
+
+    # @return [String] a concise, human-readable version of the year range, including gaps
+    def to_s
+      return if years.empty?
+      return to_s_for_streak(years) unless gaps?
+      to_s_with_gaps
+    end
+
+    # @param [Array<Integer>] `other` the set of years to add
+    def <<(other)
+      return self if other.blank?
+      @years |= other # will remove duplicates
+      @years.sort!
+      self
+    end
+
+    # @param [String] `dates` in the form YYYY/YYYY
+    # @return [Array<Integer>] the set of years in the given range
+    def parse_range(dates)
+      return if dates.blank?
+      start_year, end_year = dates.split('/').map { |date| to_year_from_iso8601(date) }
+      return [start_year] if end_year.blank?
+      raise ArgumentError, "Range is too large: #{dates}" if (end_year - start_year) > 1000
+      raise ArgumentError, "Range is inverted: #{dates}" unless start_year <= end_year
+      (start_year..end_year).to_a
+    end
+
+    # @param [Array<String>] `dates` in the form YYYY/YYYY
+    # @return [Array<Integer>] the set of years in the given range
+    def parse_ranges(dates)
+      dates.map { |date| parse_range(date) }.flatten.sort.uniq
+    end
+
+    # @param [String] `date` a date in one of these formats:
+    #                        YYYY, YYYY-MM, YYYY-MM-DD, and YYYYMMDD
+    def to_year_from_iso8601(date)
+      return if date.blank?
+      date.split('-').first[0..3].to_i # Time.parse doesn't work here
+    end
+
+    # @return [Boolean] are there gaps between the years, such as 1999, 2000, 2002?
+    def gaps?
+      return false if years.blank?
+      (years.min..years.max).to_a != years
+    end
+
+    private
+
+    # Deals with making a human-readable range for years with 1 or more gaps.
+    # It involves detection of streaks between the gaps.
+    # @return [String] 1999-2000, 2002 for 1999, 2000, 2002
+    def to_s_with_gaps # rubocop: disable Metrics/AbcSize, Metrics/MethodLength
+      raise ArgumentError if years.blank? || years.length < 2
+      results = []
+      streak = [years[0]]
+      i = streak.first
+      years[1..-1].each do |j|
+        i += 1
+        if i == j
+          streak << j
+        else # we have a gap
+          results << if streak.length == 1
+                       streak.first.to_s
+                     else
+                       to_s_for_streak(streak)
+                     end
+          streak = [j]
+          i = j
+        end
+      end
+      results << to_s_for_streak(streak)
+      results.join(', ')
+    end
+
+    def to_s_for_streak(streak)
+      return streak.min.to_s if streak.min == streak.max
+      [streak.min, streak.max].map(&:to_s).join('-')
+    end
+  end
+end

--- a/spec/features/indexing_custom_component_spec.rb
+++ b/spec/features/indexing_custom_component_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
 
         date_range_field = doc['date_range_sim']
         expect(doc['unitdate_ssm']).to eq ['1902-1976'] # the field the range is derived from
+        expect(doc['normalized_date_range_ssm']).to eq ['1902-1976']
         expect(date_range_field).to be_an Array
         expect(date_range_field.length).to eq 75
         expect(date_range_field.first).to eq '1902'
@@ -64,6 +65,7 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
 
         date_range_field = doc['date_range_sim']
         expect(doc['unitdate_ssm']).to eq ['n.d.']
+        expect(doc['normalized_date_range_ssm']).to be_nil # TODO: is this what we really want?
         expect(date_range_field).to be_nil
       end
 
@@ -72,6 +74,7 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
 
         date_range_field = doc['date_range_sim']
         expect(doc['unitdate_ssm']).to eq ['c.1902']
+        expect(doc['normalized_date_range_ssm']).to eq ['1902']
         expect(date_range_field).to eq ['1902']
       end
 
@@ -80,7 +83,32 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
 
         date_range_field = doc['date_range_sim']
         expect(doc['unitdate_ssm']).to eq ['1904']
+        expect(doc['normalized_date_range_ssm']).to eq ['1904']
         expect(date_range_field).to eq ['1904']
+      end
+
+      it 'handles odd date specifications' do
+        doc = components.find do |c|
+          c.to_solr['ref_ssm'] == ['aspace_dba76dab6f750f31aa5fc73e5402e71d']
+        end.to_solr
+        expect(doc['unitdate_ssm']).to eq ['1924-1955', '1944']
+        expect(doc['normalized_date_range_ssm']).to eq ['1924-1955']
+      end
+
+      it 'handles missing date specifications' do
+        doc = components.find do |c|
+          c.to_solr['ref_ssm'] == ['aspace_01daa89087641f7fc9dbd7a10d3f2da9']
+        end.to_solr
+        expect(doc['unitdate_ssm']).to be_nil
+        expect(doc['normalized_date_range_ssm']).to be_nil
+      end
+
+      it 'handles n.d. with a date' do
+        doc = components.find do |c|
+          c.to_solr['ref_ssm'] == ['aspace_a8b5c3a57013462581d0e807241fcf93']
+        end.to_solr
+        expect(doc['unitdate_ssm']).to eq ['1904, n.d.']
+        expect(doc['normalized_date_range_ssm']).to eq ['1904'] # TODO: is this what we want?
       end
     end
 

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -584,6 +584,7 @@
           <unittitle>Series VII: Subject Files,</unittitle>
           <unitid>MS C 271.VII</unitid>
           <unitdate normal="1924/1955" type="inclusive">1924-1955</unitdate>
+          <unitdate normal="1944/1944" type="inclusive">1944</unitdate>
         </did>
         <accessrestrict><p>Restricted until 2018.</p></accessrestrict>
       </c>

--- a/spec/lib/arclight/shared_indexing_behavior_spec.rb
+++ b/spec/lib/arclight/shared_indexing_behavior_spec.rb
@@ -10,66 +10,18 @@ end
 RSpec.describe Arclight::SharedIndexingBehavior do
   subject(:indexer) { TestClass.new }
 
-  context '#to_year_from_iso8601' do
-    it 'blanks' do
-      expect(indexer.to_year_from_iso8601(nil)).to be_nil
-      expect(indexer.to_year_from_iso8601('   ')).to be_nil
-    end
-    it 'YYYY' do
-      expect(indexer.to_year_from_iso8601('1999')).to eq 1999
-    end
-    it 'YYYY-MM' do
-      expect(indexer.to_year_from_iso8601('1999-01')).to eq 1999
-    end
-    it 'YYYY-MM-DD' do
-      expect(indexer.to_year_from_iso8601('1999-01-02')).to eq 1999
-    end
-    it 'YYYYMMDD' do
-      expect(indexer.to_year_from_iso8601('19990102')).to eq 1999
-    end
-    it 'tiny years' do
-      expect(indexer.to_year_from_iso8601('1')).to eq 1
-    end
-  end
-
-  context '#to_date_range' do
-    it 'blanks' do
-      expect(indexer.to_date_range(nil)).to be_nil
-      expect(indexer.to_date_range('   ')).to be_nil
-    end
-    it 'YYYY' do
-      expect(indexer.to_date_range('1999')).to eq %w[1999]
-    end
-    it 'YYYY/YYYY' do
-      expect(indexer.to_date_range('1999/2000')).to eq %w[1999 2000]
-    end
-    it 'too large YYYY/YYYY' do
-      expect { indexer.to_date_range('1999/9999') }.to raise_error(RuntimeError, /unsupported/i)
-    end
-    it 'YYYY-MM/YYYY' do
-      expect(indexer.to_date_range('1999-12/2000')).to eq %w[1999 2000]
-    end
-    it 'YYYY-MM-DD/YYYY' do
-      expect(indexer.to_date_range('1999-12-31/2000')).to eq %w[1999 2000]
-    end
-    it 'YYYYMMDD/YYYY' do
-      expect(indexer.to_date_range('19991231/2000')).to eq %w[1999 2000]
-    end
-  end
-
-  context '#formatted_unitdate_for_range' do
+  context '#unitdate_for_range' do
     it 'single range' do
       indexer.normal_unit_dates = %w[1999/2000]
-      expect(indexer.formatted_unitdate_for_range).to eq %w[1999 2000]
+      expect(indexer.unitdate_for_range.to_s).to eq '1999-2000'
     end
     it 'multiple ranges will warn and only pick first' do
       indexer.normal_unit_dates = %w[1999/2000 2010/2011]
-      expect($stdout).to receive(:puts).with(/warning.*unsupported/i) # rubocop: disable RSpec/MessageSpies
-      expect(indexer.formatted_unitdate_for_range).to eq %w[1999 2000]
+      expect(indexer.unitdate_for_range.to_s).to eq '1999-2000, 2010-2011'
     end
     it 'bogus call' do
       indexer.normal_unit_dates = %w[]
-      expect(indexer.formatted_unitdate_for_range).to be_nil
+      expect(indexer.unitdate_for_range.to_s).to be_nil
     end
   end
 end

--- a/spec/lib/arclight/year_range_spec.rb
+++ b/spec/lib/arclight/year_range_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Arclight::YearRange do
+  subject(:range) { described_class.new }
+
+  context '#initialize' do
+    it 'takes blanks' do
+      expect(described_class.new.years.length).to eq 0
+    end
+    it 'takes ranges' do
+      expect(described_class.new(%w[1999 2002/2003]).years.length).to eq 3
+    end
+  end
+
+  context '#to_year_from_iso8601' do
+    it 'blanks' do
+      expect(range.to_year_from_iso8601(nil)).to be_nil
+      expect(range.to_year_from_iso8601('   ')).to be_nil
+    end
+    it 'YYYY' do
+      expect(range.to_year_from_iso8601('1999')).to eq 1999
+    end
+    it 'YYYY-MM' do
+      expect(range.to_year_from_iso8601('1999-01')).to eq 1999
+    end
+    it 'YYYY-MM-DD' do
+      expect(range.to_year_from_iso8601('1999-01-02')).to eq 1999
+    end
+    it 'YYYYMM' do
+      expect(range.to_year_from_iso8601('199901')).to eq 1999
+    end
+    it 'YYYYMMDD' do
+      expect(range.to_year_from_iso8601('19990102')).to eq 1999
+    end
+    it 'tiny YYYY' do
+      expect(range.to_year_from_iso8601('1')).to eq 1
+    end
+  end
+
+  context '#parse_range' do
+    it 'blanks' do
+      expect(range.parse_range(nil)).to be_nil
+      expect(range.parse_range('   ')).to be_nil
+    end
+    it 'YYYY' do
+      expect(range.parse_range('1999')).to eq((1999..1999).to_a)
+    end
+    it 'YYYY/YYYY' do
+      expect(range.parse_range('1999/2000')).to eq((1999..2000).to_a)
+    end
+    it 'YYYY-MM/YYYY' do
+      expect(range.parse_range('1999-12/2000')).to eq((1999..2000).to_a)
+    end
+    it 'YYYY-MM-DD/YYYY' do
+      expect(range.parse_range('1999-12-31/2000')).to eq((1999..2000).to_a)
+    end
+    it 'YYYYMMDD/YYYY' do
+      expect(range.parse_range('19991231/2000')).to eq((1999..2000).to_a)
+    end
+    it 'inverted YYYY/YYYY' do
+      expect { range.parse_range('1999/1998') }.to raise_error(ArgumentError, /inverted/i)
+    end
+    it 'too large YYYY/YYYY' do
+      expect { range.parse_range('1999/9999') }.to raise_error(ArgumentError, /too large/i)
+    end
+  end
+
+  context '#parse_ranges' do
+    it 'empty call' do
+      expect(range.parse_ranges([])).to be_empty
+    end
+    it 'single range' do
+      expect(range.parse_ranges(%w[1999/2000])).to eq [1999, 2000]
+    end
+    it 'simple multiple ranges' do
+      expect(range.parse_ranges(%w[1999/2000 2002/2003])).to eq [1999, 2000, 2002, 2003]
+    end
+    it 'multiple ranges with overlaps' do
+      expect(range.parse_ranges(%w[1999/2005 2002/2003 2004/2004])).to eq [1999, 2000, 2001, 2002, 2003, 2004, 2005]
+    end
+  end
+
+  context '#gaps?' do
+    it 'single year' do
+      range << [1999]
+      expect(range.gaps?).to be_falsey
+    end
+    it 'simple range' do
+      range << [1999, 2000]
+      expect(range.gaps?).to be_falsey
+    end
+    it 'multiple ranges with gaps' do
+      range << [1999, 2000] << [2002, 2003]
+      expect(range.gaps?).to be_truthy
+    end
+  end
+
+  context '#to_s' do
+    it 'no years' do
+      expect(described_class.new.to_s).to be_nil
+    end
+    it 'single year' do
+      range << [1999]
+      expect(range.to_s).to eq '1999'
+    end
+    it 'simple range' do
+      range << [1999, 2000]
+      expect(range.to_s).to eq '1999-2000'
+    end
+    it 'large range' do
+      range << (1900..2000).to_a
+      expect(range.to_s).to eq '1900-2000'
+    end
+    it 'multiple ranges' do
+      range << [1999, 2000] << [2001, 2002, 2003] << [2004]
+      expect(range.to_s).to eq '1999-2004'
+    end
+    it 'multiple ranges with single-year runs' do
+      range << [1999] << [2002] << [2004]
+      expect(range.to_s).to eq '1999, 2002, 2004'
+    end
+    it 'multiple ranges with single-year gaps' do
+      range << [1999, 2000] << [2002]
+      expect(range.to_s).to eq '1999-2000, 2002'
+    end
+    it 'multiple ranges with multi-year gaps and short run' do
+      range << [1999] << [2002]
+      expect(range.to_s).to eq '1999, 2002'
+    end
+    it 'multiple ranges with multi-year gaps and long run' do
+      range << [1999, 2000] << [2002, 2003]
+      expect(range.to_s).to eq '1999-2000, 2002-2003'
+    end
+  end
+end


### PR DESCRIPTION
This PR is connected to #305 and fixes #306. It primarily does 2 things:

1. Uses all of the `unitdate`'s text for the title. Previously it was using the first `unitdate` only.
2. When there are multiple unitdate's, it uses the `normal` attribute to generate the `date_range_sim` facet for the by-year range functionality. That includes gaps in the ranges, like 1999/2002, 2004/2005.

Note that the `YearRange` class is fairly extensive as the spec handles a lot of cases. Also, I created the `normalized_date_range` field for future use -- it uses the `normal` attribute data (rather than the `text()` data) to generate a human-readable date range based on the years in the facet.

There's still some issues with odd date range specifications. See #305 for details. I added a multiple unitdate specification to our fixture EAD data.

**Various examples, which have "YYYY, n.d."**

![screen shot 2017-05-11 at 3 29 04 pm](https://cloud.githubusercontent.com/assets/1861171/25974587/c115187a-365e-11e7-8471-f0b7182c01cd.png)

**Example where the unitdate values are redundant**

![screen shot 2017-05-11 at 3 38 21 pm](https://cloud.githubusercontent.com/assets/1861171/25974843/e837724e-365f-11e7-8be6-cb85b74413b4.png)

BUT using the `normal` attribute data we get what you'd expect:

![screen shot 2017-05-11 at 3 39 44 pm](https://cloud.githubusercontent.com/assets/1861171/25974893/2b6c5124-3660-11e7-8095-c8d7d3513d96.png)


**Case where unitdate values are multiple but include already-specified date range**

![screen shot 2017-05-11 at 3 27 06 pm](https://cloud.githubusercontent.com/assets/1861171/25974517/5828ce74-365e-11e7-8201-b0535bb7f02c.png)
