### PR TITLE
Adjust responsive layout for Bookmark checkbox

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -2,3 +2,11 @@
   font-size: $font-size-sm;
   margin-bottom: $spacer;
 }
+
+.al-document-title-bar {
+  .toggle-bookmark {
+    @media (min-width: 576px) and (max-width: 991px) {
+      padding-right: $spacer;
+    }
+  }
+}

--- a/app/views/catalog/_arclight_document_index_header.html.erb
+++ b/app/views/catalog/_arclight_document_index_header.html.erb
@@ -1,11 +1,11 @@
 <% document_actions = capture do %>
   <% # bookmark functions for items/docs -%>
-  <%= render_index_doc_actions document, wrapping_class: "col-3 text-right" %>
+  <%= render_index_doc_actions document, wrapping_class: "col-5 col-sm-3 text-right" %>
 <% end %>
 
 <div class='al-document-title-bar'>
   <div class='row'>
-    <div class='col-9'>
+    <div class='col-7 col-sm-9'>
       <%= document.repository_and_unitid %>
     </div>
     <%= document_actions %>

--- a/app/views/catalog/_arclight_document_show_header.html.erb
+++ b/app/views/catalog/_arclight_document_show_header.html.erb
@@ -5,10 +5,10 @@
 
 <div class='al-document-title-bar'>
   <div class='row'>
-    <div class='col-9'>
+    <div class='col-7 col-sm-9'>
       <%= document.repository_and_unitid %>
     </div>
-    <div class='col-3 text-right'>
+    <div class='col-5 col-sm-3 text-right'>
       <%= document_actions %>
     </div>
   </div>


### PR DESCRIPTION
This PR, combined with this [Blacklight PR](https://github.com/projectblacklight/blacklight/pull/1700), fixes part of #266, where the Bookmark checkbox was displayed outside of its container at small viewports.

The other part of #266 is not addressed in this PR so we should leave #266 open.

### Before
![86e473e4-304b-11e7-8e59-94af85964973](https://cloud.githubusercontent.com/assets/101482/25976774/f13986dc-366b-11e7-9b93-0d095cb999f1.png)

### After - Collections
![level__collection_-_blacklight_search_results](https://cloud.githubusercontent.com/assets/101482/25976740/b000e58e-366b-11e7-9bfe-c54a97151db2.png)


### After - Component detail
![constitution_-_notes_on_drafting_of_constitution__c_1902-1903_-_blacklight](https://cloud.githubusercontent.com/assets/101482/25976735/acce2e9e-366b-11e7-9803-1f6f566f61b5.png)
