### PR TITLE
Add the collection creator to a display field for components

### DIFF
--- a/app/models/arclight/requests/google_form.rb
+++ b/app/models/arclight/requests/google_form.rb
@@ -7,7 +7,7 @@ module Arclight
     # query parameters from the form mapping configuratino
     class GoogleForm
       attr_reader :document, :presenter, :document_url
-      delegate :collection_name, :eadid, :containers, to: :document
+      delegate :collection_name, :collection_creator, :eadid, :containers, to: :document
 
       ##
       # @param [Blacklight::SolrDocument] document

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -57,6 +57,10 @@ module Arclight
       first('creator_ssm')
     end
 
+    def collection_creator
+      first('collection_creator_ssm')
+    end
+
     def online_content?
       first('has_online_content_ssm') == 'true'
     end

--- a/lib/arclight/solr_ead_indexer_ext.rb
+++ b/lib/arclight/solr_ead_indexer_ext.rb
@@ -12,6 +12,8 @@ module Arclight
 
       add_count_of_child_compontents(node, solr_doc)
 
+      add_collection_creator_to_component(node, solr_doc)
+
       solr_doc
     end
 
@@ -50,6 +52,14 @@ module Arclight
 
     def add_count_of_child_compontents(node, solr_doc)
       solr_doc[Solrizer.solr_name('child_component_count', type: :integer)] = node.xpath('count(c)').to_i
+    end
+
+    # This mimics similar behavior in Arclight::CustomDocument
+    def add_collection_creator_to_component(node, solr_doc)
+      field_name = Solrizer.solr_name('collection_creator', :displayable)
+      repository = solr_doc[Solrizer.solr_name('repository', :displayable)]
+      creators = node.xpath('//archdesc/did/origination[@label="creator"]/*/text()').map(&:text)
+      solr_doc[field_name] = creators - [repository]
     end
   end
 end

--- a/lib/generators/arclight/templates/config/repositories.yml
+++ b/lib/generators/arclight/templates/config/repositories.yml
@@ -12,7 +12,7 @@ nlm:
   contact_info: 'hmdref@nlm.nih.gov'
   thumbnail_url: "https://collections.nlm.nih.gov/pageturnerserver/ajaxp?theurl=http://localhost:8080/fedora/get/nlm:nlmuid-101421040-img/THUMB"
   google_request_url: 'https://docs.google.com/a/stanford.edu/forms/d/e/1FAIpQLSeOamhY_IcFw4sPnz0ddwWWkrPaHbM5wp7JVbOLOL_mIusEyw/viewform'
-  google_request_mappings: "document_url=entry.1980510262&collection_name=entry.619150170&eadid=entry.996397105&containers=entry.1125277048&title=entry.862815208"
+  google_request_mappings: "document_url=entry.1980510262&collection_name=entry.619150170&collection_creator=entry.14428541&eadid=entry.996397105&containers=entry.1125277048&title=entry.862815208"
 sul-spec:
   name: 'Stanford University Libraries. Special Collections and University Archives'
   visit_note: 'Special Collections and University Archives materials are stored offsite and must be paged 36 hours in advance.'

--- a/spec/features/google_form_request_spec.rb
+++ b/spec/features/google_form_request_spec.rb
@@ -14,7 +14,9 @@ describe 'Google Form Request', type: :feature, js: true do
             'input[name="entry.1980510262"][value$="catalog/aoa271aspace_843e8f9f22bac69872d0802d6fffbb04"]',
             visible: false
           )
+
           expect(page).to have_css 'input[name="entry.619150170"][value="Alpha Omega Alpha Archives"]', visible: false
+          expect(page).to have_css 'input[name="entry.14428541"][value="Alpha Omega Alpha"]', visible: false
           expect(page).to have_css 'input[name="entry.996397105"][value="aoa271"]', visible: false
           expect(page).to have_css 'input[name="entry.1125277048"][value="box 1 folder 1"]', visible: false
           expect(page).to have_css 'input[name="entry.862815208"][value$="William W. Root, n.d."]', visible: false

--- a/spec/fixtures/config/repositories.yml
+++ b/spec/fixtures/config/repositories.yml
@@ -42,7 +42,7 @@ nlm:
   contact_info: 'hmdref@nlm.nih.gov'
   thumbnail_url: "https://collections.nlm.nih.gov/pageturnerserver/ajaxp?theurl=http://localhost:8080/fedora/get/nlm:nlmuid-101421040-img/THUMB"
   google_request_url: 'https://docs.google.com/a/stanford.edu/forms/d/e/1FAIpQLSeOamhY_IcFw4sPnz0ddwWWkrPaHbM5wp7JVbOLOL_mIusEyw/viewform'
-  google_request_mappings: "document_url=entry.1980510262&collection_name=entry.619150170&eadid=entry.996397105&containers=entry.1125277048&title=entry.862815208"
+  google_request_mappings: "document_url=entry.1980510262&collection_name=entry.619150170&collection_creator=entry.14428541&eadid=entry.996397105&containers=entry.1125277048&title=entry.862815208"
 
 umich-bhl:
   name: 'University of Michigan. Bentley Historical Library'

--- a/spec/lib/arclight/indexer_spec.rb
+++ b/spec/lib/arclight/indexer_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe Arclight::Indexer do
     end
   end
 
+  describe '#add_collection_creator_to_component' do
+    it 'adds the creator of the collection to a stored non-indexed/faceted field' do
+      node = xml.xpath('//c[@id="aspace_563a320bb37d24a9e1e6f7bf95b52671"]').first
+      fields = indexer.additional_component_fields(node)
+      expect(fields['creator_ssim']).to be_nil
+      expect(fields['collection_creator_ssm']).to eq ['Alpha Omega Alpha']
+    end
+  end
+
   describe 'delete_all' do
     before do
       expect(indexer).to receive_messages(solr: solr_client)


### PR DESCRIPTION
Closes #310 

Note, this doesn't add anything to the Collection Context section because Arclight renders that data from the collection record itself (and we'll get that for free when we add the creator there).

## Request Form
<img width="612" alt="collection-creator-form" src="https://cloud.githubusercontent.com/assets/96776/26012134/5fa8188a-3708-11e7-8f75-63d0042fe5f7.png">

