### PR TITLE
normalize collection and component titles to use "Title, Date" throughout the app

### DIFF
--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -39,12 +39,6 @@ module Arclight
       first('collection_ssm')
     end
 
-    def unitdate
-      date = fetch('unitdate_ssm', []).join(', ')
-      return if date.blank?
-      date
-    end
-
     def extent
       first('extent_ssm')
     end
@@ -88,6 +82,14 @@ module Arclight
 
     def containers
       fetch('containers_ssim', [])
+    end
+
+    def normalized_title
+      first('normalized_title_ssm')
+    end
+
+    def normalized_date
+      first('normalized_date_ssm')
     end
   end
 end

--- a/app/presenters/arclight/index_presenter.rb
+++ b/app/presenters/arclight/index_presenter.rb
@@ -4,19 +4,7 @@ module Arclight
   # Custom presentation methods for index partials
   class IndexPresenter < Blacklight::IndexPresenter
     def label(*)
-      view_context.safe_join([normalize_title(super), document.unitdate].compact.map(&:html_safe), ', ')
-    end
-
-    private
-
-    # TODO: duplicate of ShowPresenter#normalize_title
-    def normalize_title(title)
-      if document.unitdate.blank?
-        return document.id.to_s if title.blank? # fallback to id when nothing there
-      elsif title.blank? || title == document.id.to_s # unitdate is present
-        return nil
-      end
-      title.gsub(/\s*,\s*$/, '') # strip trailing commas
+      document.normalized_title
     end
   end
 end

--- a/app/presenters/arclight/show_presenter.rb
+++ b/app/presenters/arclight/show_presenter.rb
@@ -4,7 +4,7 @@ module Arclight
   # Custom presentation methods for show partial
   class ShowPresenter < Blacklight::ShowPresenter
     def heading
-      view_context.safe_join([normalize_title(super), document.unitdate].compact.map(&:html_safe), ', ')
+      document.normalized_title
     end
 
     def with_field_group(group)
@@ -22,16 +22,6 @@ module Arclight
 
     def field_config(field)
       BlacklightFieldConfigurationFactory.for(config: configuration, field: field, field_group: field_group)
-    end
-
-    # TODO: duplicate of IndexPresenter#normalize_title
-    def normalize_title(title)
-      if document.unitdate.blank?
-        return document.id.to_s if title.blank? # fallback to id when nothing there
-      elsif title.blank? || title == document.id.to_s # unitdate is present
-        return nil
-      end
-      title.gsub(/\s*,\s*$/, '') # strip trailing commas
     end
   end
 end

--- a/lib/arclight/custom_component.rb
+++ b/lib/arclight/custom_component.rb
@@ -17,6 +17,9 @@ module Arclight
       t.level(path: 'c/@level', index_as: %i[displayable]) # machine-readable for string `level_ssm`
       t.extent(path: 'c/did/physdesc/extent', index_as: %i[displayable])
       t.unitdate(path: 'c/did/unitdate', index_as: %i[displayable])
+      t.unitdate_inclusive(path: 'c/did/unitdate[@type=\'inclusive\']', index_as: %i[displayable])
+      t.unitdate_bulk(path: 'c/did/unitdate[@type=\'bulk\']', index_as: %i[displayable])
+      t.unitdate_other(path: 'c/did/unitdate[not(@type)]', index_as: %i[displayable])
       t.accessrestrict(path: 'c/accessrestrict/p', index_as: %i[displayable])
       t.scopecontent(path: 'c/scopecontent/p', index_as: %i[displayable])
       t.normal_unit_dates(path: 'c/did/unitdate/@normal')
@@ -29,6 +32,7 @@ module Arclight
       Solrizer.insert_field(solr_doc, 'access_subjects', access_subjects, :facetable)
       Solrizer.insert_field(solr_doc, 'containers', containers, :symbol)
       add_date_ranges(solr_doc)
+      add_normalized_title(solr_doc)
       resolve_repository(solr_doc)
       add_digital_content(prefix: 'c/did', solr_doc: solr_doc)
 

--- a/lib/arclight/custom_document.rb
+++ b/lib/arclight/custom_document.rb
@@ -23,6 +23,9 @@ module Arclight
       # overrides of solr_ead to get different `index_as` properties
       t.extent(path: 'archdesc/did/physdesc/extent', index_as: %i[displayable])
       t.unitdate(path: 'archdesc/did/unitdate', index_as: %i[displayable])
+      t.unitdate_inclusive(path: 'archdesc/did/unitdate[@type=\'inclusive\']', index_as: %i[displayable])
+      t.unitdate_bulk(path: 'archdesc/did/unitdate[@type=\'bulk\']', index_as: %i[displayable])
+      t.unitdate_other(path: 'archdesc/did/unitdate[not(@type)]', index_as: %i[displayable])
       t.accessrestrict(path: 'archdesc/accessrestrict/p', index_as: %i[displayable])
       t.scopecontent(path: 'archdesc/scopecontent/p', index_as: %i[displayable])
       t.userestrict(path: 'archdesc/userestrict/p', index_as: %i[displayable])
@@ -50,11 +53,18 @@ module Arclight
 
       add_date_ranges(solr_doc)
       add_digital_content(prefix: 'ead/archdesc', solr_doc: solr_doc)
+      add_normalized_titles(solr_doc)
 
       solr_doc
     end
 
     private
+
+    def add_normalized_titles(solr_doc)
+      title = add_normalized_title(solr_doc)
+      solr_doc['collection_sim'] = [title]
+      solr_doc['collection_ssm'] = [title]
+    end
 
     def arclight_field_definitions
       [

--- a/lib/arclight/engine.rb
+++ b/lib/arclight/engine.rb
@@ -2,7 +2,9 @@
 
 require 'blacklight'
 require 'solr_ead'
+require 'arclight/normalized_date'
 require 'arclight/normalized_id'
+require 'arclight/normalized_title'
 require 'arclight/digital_object'
 require 'arclight/shared_indexing_behavior'
 require 'arclight/custom_document'

--- a/lib/arclight/normalized_date.rb
+++ b/lib/arclight/normalized_date.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Arclight
+  ##
+  # A utility class to normalize dates, typically by joining inclusive and bulk dates
+  # e.g., "1990-2000, bulk 1990-1999"
+  # @see http://www2.archivists.org/standards/DACS/part_I/chapter_2/4_date
+  class NormalizedDate
+    # @param [String | Array<String>] `inclusive` from the `unitdate`
+    # @param [String] `bulk` from the `unitdate`
+    # @param [String] `other` from the `unitdate` when type is not specified
+    def initialize(inclusive, bulk = nil, other = nil)
+      if inclusive.is_a? Array # of YYYY-YYYY for ranges
+        @inclusive = YearRange.new(inclusive.include?('/') ? inclusive : inclusive.map { |v| v.tr('-', '/') }).to_s
+      elsif inclusive.present?
+        @inclusive = inclusive.strip
+      end
+      @bulk = bulk.strip if bulk.present?
+      @other = other.strip if other.present?
+    end
+
+    # @return [String] the normalized title/date
+    def to_s
+      normalize
+    end
+
+    private
+
+    attr_reader :inclusive, :bulk, :other
+
+    # @see http://www2.archivists.org/standards/DACS/part_I/chapter_2/4_date for rules
+    def normalize
+      if inclusive.present?
+        result = inclusive.to_s
+        result << ", bulk #{bulk}" if bulk.present?
+      elsif other.present?
+        result = other.to_s
+      else
+        result = nil
+      end
+      return if result.blank?
+      result.strip
+    end
+  end
+end

--- a/lib/arclight/normalized_title.rb
+++ b/lib/arclight/normalized_title.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Arclight
+  ##
+  # A utility class to normalize titles, typically by joining
+  # the title and date, e.g., "My Title, 1990-2000"
+  class NormalizedTitle
+    # @param [String] `title` from the `unittitle`
+    # @param [String] `date` from the `unitdate`
+    # @param [String] `default` the fallback for the title (e.g., an id)
+    def initialize(title, date = nil, default = nil)
+      @title = title.gsub(/\s*,\s*$/, '').strip if title.present?
+      @date = date.strip if date.present?
+      @default = default
+    end
+
+    # @return [String] the normalized title/date
+    def to_s
+      normalize
+    end
+
+    private
+
+    attr_reader :title, :date, :default
+
+    def normalize
+      result = [title, date].compact.join(', ')
+      return default.to_s if result.blank?
+      result
+    end
+  end
+end

--- a/lib/arclight/shared_indexing_behavior.rb
+++ b/lib/arclight/shared_indexing_behavior.rb
@@ -74,7 +74,14 @@ module Arclight
 
     def add_date_ranges(solr_doc)
       Solrizer.insert_field(solr_doc, 'date_range', unitdate_for_range.years, :facetable)
-      Solrizer.insert_field(solr_doc, 'normalized_date_range', unitdate_for_range.to_s, :displayable)
+    end
+
+    def add_normalized_title(solr_doc)
+      dates = Arclight::NormalizedDate.new(unitdate_inclusive.first, unitdate_bulk.first, unitdate_other.first).to_s
+      title = Arclight::NormalizedTitle.new(solr_doc['title_ssm'].first, dates, solr_doc['id'].to_s).to_s
+      solr_doc['normalized_title_ssm'] = [title]
+      solr_doc['normalized_date_ssm'] = [dates]
+      title
     end
   end
 end

--- a/lib/arclight/solr_ead_indexer_ext.rb
+++ b/lib/arclight/solr_ead_indexer_ext.rb
@@ -3,14 +3,14 @@
 module Arclight
   ##
   # An module to extend SolrEad::Indexer behaviors to allow us to add
-  # additional behaviors that require knowledge of the entire XML document.
+  # or override behaviors that require knowledge of the entire XML document.
   module SolrEadIndexerExt
     def additional_component_fields(node, addl_fields = {})
       solr_doc = super
 
-      add_collection_context_to_parent_fields(node, solr_doc)
-
       add_count_of_child_compontents(node, solr_doc)
+      add_ancestral_titles(node, solr_doc)
+      add_ancestral_ids(node, solr_doc)
 
       solr_doc
     end
@@ -22,34 +22,99 @@ module Arclight
 
     private
 
-    ##
-    # SolrEad does not index the collection id/title into the parent
-    # fields, so we're adding that context to the beginning of those fields
-    def add_collection_context_to_parent_fields(node, solr_doc)
-      add_collection_id(node, solr_doc)
-      add_collection_title(node, solr_doc)
+    # Note that we need to redo what solr_ead does for ids due to our normalization process
+    def add_ancestral_ids(node, solr_doc)
+      @parent_id_name ||= Solrizer.solr_name('parent', :stored_sortable)
+      @parent_ids_field_name ||= Solrizer.solr_name('parent', :displayable)
+      @parent_ids_search_field_name ||= Solrizer.solr_name('parent', :searchable)
+
+      ids = ancestral_ids(node)
+      solr_doc[@parent_ids_field_name] = ids
+      solr_doc[@parent_ids_search_field_name] = ids
+      solr_doc[@parent_id_name] = ids.last
     end
 
-    def add_collection_id(node, solr_doc)
-      eadid = Arclight::NormalizedId.new(node.xpath('//eadid').text).to_s
-      parent_id_field_name = Solrizer.solr_name('parent', :stored_sortable)
-      parent_ids_field_name = Solrizer.solr_name('parent', :displayable)
+    # Note that we need to redo what solr_ead does for titles due to our normalization process
+    def add_ancestral_titles(node, solr_doc)
+      @parent_titles_field_name ||= Solrizer.solr_name('parent_unittitles', :displayable)
+      @parent_titles_search_field_name ||= Solrizer.solr_name('parent_unittitles', :searchable)
+      @collection_facet_name ||= Solrizer.solr_name('collection', :facetable)
+      @collection_name ||= Solrizer.solr_name('collection', :displayable)
 
-      solr_doc[parent_id_field_name] = eadid if solr_doc[parent_id_field_name].blank?
-      solr_doc[parent_ids_field_name] = (solr_doc[parent_ids_field_name] || []).unshift(eadid)
-    end
-
-    def add_collection_title(node, solr_doc)
-      eadtitle = node.xpath('//archdesc/did/unittitle').text
-      parent_titles_field_name = Solrizer.solr_name('parent_unittitles', :displayable)
-      parent_titles_search_field_name = Solrizer.solr_name('parent_unittitles', :searchable)
-
-      solr_doc[parent_titles_field_name] = (solr_doc[parent_titles_field_name] || []).unshift(eadtitle)
-      solr_doc[parent_titles_search_field_name] = (solr_doc[parent_titles_search_field_name] || []).unshift(eadtitle)
+      titles = ancestral_titles(node)
+      solr_doc[@parent_titles_field_name] = titles
+      solr_doc[@parent_titles_search_field_name] = titles
+      solr_doc[@collection_name] = [titles.first] # collection is always on top
+      solr_doc[@collection_facet_name] = [titles.first]
     end
 
     def add_count_of_child_compontents(node, solr_doc)
-      solr_doc[Solrizer.solr_name('child_component_count', type: :integer)] = node.xpath('count(c)').to_i
+      @child_component_count_name ||= Solrizer.solr_name('child_component_count', type: :integer)
+
+      solr_doc[@child_component_count_name] = node.xpath('count(c)').to_i
+    end
+
+    def ancestral_ids(node)
+      ancestral_visit(node, :normalized_component_id, :normalized_collection_id)
+    end
+
+    def ancestral_titles(node)
+      ancestral_visit(node, :normalized_component_title, :normalized_collection_title)
+    end
+
+    # visit each component's parent and finish with a visit on the collection
+    def ancestral_visit(node, component_fn, collection_fn, results = [])
+      while node.parent && node.parent.name == 'c'
+        parent = node.parent
+        results << send(component_fn, parent)
+        node = parent
+      end
+      results << send(collection_fn, node)
+      results.reverse
+    end
+
+    def normalized_component_title(node)
+      data = extract_title_and_dates(node)
+      normalize_title(data, normalized_component_id(node))
+    end
+
+    def normalized_collection_title(node)
+      data = extract_title_and_dates(node, '//archdesc/')
+      normalize_title(data, normalized_collection_id(node))
+    end
+
+    def normalize_title(data, id)
+      Arclight::NormalizedTitle.new(
+        data[:title],
+        Arclight::NormalizedDate.new(
+          data[:unitdate_inclusive],
+          data[:unitdate_bulk],
+          data[:unitdate_other]
+        ).to_s,
+        id.to_s
+      ).to_s
+    end
+
+    # TODO: these xpaths should be DRY'd up -- they're in both terminologies
+    def extract_title_and_dates(node, prefix = nil)
+      data = {
+        title:              node.at_xpath("#{prefix}did/unittitle"),
+        unitdate_inclusive: node.at_xpath("#{prefix}did/unitdate[@type=\"inclusive\"]"),
+        unitdate_bulk:      node.at_xpath("#{prefix}did/unitdate[@type=\"bulk\"]"),
+        unitdate_other:     node.at_xpath("#{prefix}did/unitdate[not(@type)]")
+      }
+      data.each do |k, v|
+        data[k] = v.text if v
+      end
+      data
+    end
+
+    def normalized_component_id(node)
+      Arclight::NormalizedId.new(node['id'].to_s).to_s
+    end
+
+    def normalized_collection_id(node)
+      Arclight::NormalizedId.new(node.document.at_xpath('//eadid').text).to_s
     end
   end
 end

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -38,7 +38,7 @@ class CatalogController < ApplicationController
     #}
 
     # solr field configuration for search results/index views
-    config.index.title_field = 'title_ssm'
+    config.index.title_field = 'normalized_title_ssm'
     config.index.display_type_field = 'level_ssm'
     #config.index.thumbnail_field = 'thumbnail_path_ss'
 
@@ -91,7 +91,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field 'unitid_ssm', label: 'Unit ID'
     config.add_index_field 'repository_ssm', label: 'Repository'
-    config.add_index_field 'unitdate_ssm', label: 'Date'
+    config.add_index_field 'normalized_date_ssm', label: 'Date'
     config.add_index_field 'creator_ssm', label: 'Creator'
     config.add_index_field 'language_ssm', label: 'Language'
     config.add_index_field 'scopecontent_ssm', label: 'Scope Content'
@@ -173,7 +173,7 @@ class CatalogController < ApplicationController
     config.show.component_metadata_partials = [
       :component_field
     ]
-    
+
     # Component Show Page - Metadata Section
     config.add_component_field 'containers_ssim', label: 'Containers'
     config.add_component_field 'abstract_ssm', label: 'Abstract'

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -111,7 +111,8 @@
          repository_ssm,
          scopecontent_ssm,
          title_ssm,
-         unitdate_ssm,
+         normalized_title_ssm,
+         normalized_date_ssm,
          unitid_ssm,
          parent_ssm,
          parent_unittitles_ssm,
@@ -129,6 +130,7 @@
        <str name="facet.field">geogname_sim</str>
        <str name="facet.field">access_subjects_sim</str>
        <str name="facet.field">repository_sim</str>
+       <str name="facet.field">collection_sim</str>
 
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>

--- a/spec/features/google_form_request_spec.rb
+++ b/spec/features/google_form_request_spec.rb
@@ -14,7 +14,8 @@ describe 'Google Form Request', type: :feature, js: true do
             'input[name="entry.1980510262"][value$="catalog/aoa271aspace_843e8f9f22bac69872d0802d6fffbb04"]',
             visible: false
           )
-          expect(page).to have_css 'input[name="entry.619150170"][value="Alpha Omega Alpha Archives"]', visible: false
+          expect(page).to have_css('input[name="entry.619150170"][value="Alpha Omega Alpha Archives, 1894-1992"]',
+                                   visible: false)
           expect(page).to have_css 'input[name="entry.996397105"][value="aoa271"]', visible: false
           expect(page).to have_css 'input[name="entry.1125277048"][value="box 1 folder 1"]', visible: false
           expect(page).to have_css 'input[name="entry.862815208"][value$="William W. Root, n.d."]', visible: false

--- a/spec/features/indexing_custom_component_spec.rb
+++ b/spec/features/indexing_custom_component_spec.rb
@@ -47,13 +47,59 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
       end
     end
 
+    describe '#normalize_title and date' do
+      it 'has both inclusive and bulk' do
+        doc = components[0].to_solr
+        expect(doc['normalized_date_ssm']).to eq ['1902-1976, bulk 1975-1976']
+        expect(doc['normalized_title_ssm']).to eq ['Series I: Administrative Records, 1902-1976, bulk 1975-1976']
+      end
+
+      it 'has no normal attribute' do
+        doc = components[1].to_solr
+        expect(doc['normalized_date_ssm']).to eq ['n.d.']
+        expect(doc['normalized_title_ssm'].first).to match(/^"A brief account of the .*, n\.d\./m)
+      end
+
+      it 'uses circa' do
+        doc = components[2].to_solr
+        expect(doc['normalized_date_ssm']).to eq ['c.1902']
+        expect(doc['normalized_title_ssm']).to eq ['Statements of purpose, c.1902']
+      end
+
+      it 'uses inclusive YYYY' do
+        doc = components[6].to_solr
+        expect(doc['normalized_date_ssm']).to eq ['1904']
+        expect(doc['normalized_title_ssm'].first).to match(/^The constitution of the .*, 1904/m)
+      end
+
+      it 'handles missing date specifications' do
+        doc = components.find do |c|
+          c.to_solr['ref_ssm'] == ['aspace_01daa89087641f7fc9dbd7a10d3f2da9']
+        end.to_solr
+        expect(doc['normalized_date_ssm'].first).to be_nil
+      end
+
+      it 'handles n.d. with a date for non-best practice unitdate attributes' do
+        doc = components.find do |c|
+          c.to_solr['ref_ssm'] == ['aspace_a8b5c3a57013462581d0e807241fcf93']
+        end.to_solr
+        expect(doc['normalized_date_ssm']).to eq ['1904, n.d.']
+      end
+    end
+
+    describe '#parents' do
+      it 'has a reference' do
+        doc = components[1].to_solr
+        expect(doc['ref_ssi']).to eq 'aspace_843e8f9f22bac69872d0802d6fffbb04'
+        expect(doc['ref_ssm']).to eq ['aspace_843e8f9f22bac69872d0802d6fffbb04']
+      end
+      it 'should check on the entire parents ids, etc. but we need to integrate solr_ead_indexer_ext here'
+    end
+
     describe '#date_range' do
       it 'includes an array of all the years in a particular unit-date range described in YYYY/YYYY format' do
         doc = components[0].to_solr
-
         date_range_field = doc['date_range_sim']
-        expect(doc['unitdate_ssm']).to eq ['1902-1976'] # the field the range is derived from
-        expect(doc['normalized_date_range_ssm']).to eq ['1902-1976']
         expect(date_range_field).to be_an Array
         expect(date_range_field.length).to eq 75
         expect(date_range_field.first).to eq '1902'
@@ -64,8 +110,6 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
         doc = components[1].to_solr
 
         date_range_field = doc['date_range_sim']
-        expect(doc['unitdate_ssm']).to eq ['n.d.']
-        expect(doc['normalized_date_range_ssm']).to be_nil # TODO: is this what we really want?
         expect(date_range_field).to be_nil
       end
 
@@ -73,8 +117,6 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
         doc = components[2].to_solr
 
         date_range_field = doc['date_range_sim']
-        expect(doc['unitdate_ssm']).to eq ['c.1902']
-        expect(doc['normalized_date_range_ssm']).to eq ['1902']
         expect(date_range_field).to eq ['1902']
       end
 
@@ -82,33 +124,7 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
         doc = components[6].to_solr
 
         date_range_field = doc['date_range_sim']
-        expect(doc['unitdate_ssm']).to eq ['1904']
-        expect(doc['normalized_date_range_ssm']).to eq ['1904']
         expect(date_range_field).to eq ['1904']
-      end
-
-      it 'handles odd date specifications' do
-        doc = components.find do |c|
-          c.to_solr['ref_ssm'] == ['aspace_dba76dab6f750f31aa5fc73e5402e71d']
-        end.to_solr
-        expect(doc['unitdate_ssm']).to eq ['1924-1955', '1944']
-        expect(doc['normalized_date_range_ssm']).to eq ['1924-1955']
-      end
-
-      it 'handles missing date specifications' do
-        doc = components.find do |c|
-          c.to_solr['ref_ssm'] == ['aspace_01daa89087641f7fc9dbd7a10d3f2da9']
-        end.to_solr
-        expect(doc['unitdate_ssm']).to be_nil
-        expect(doc['normalized_date_range_ssm']).to be_nil
-      end
-
-      it 'handles n.d. with a date' do
-        doc = components.find do |c|
-          c.to_solr['ref_ssm'] == ['aspace_a8b5c3a57013462581d0e807241fcf93']
-        end.to_solr
-        expect(doc['unitdate_ssm']).to eq ['1904, n.d.']
-        expect(doc['normalized_date_range_ssm']).to eq ['1904'] # TODO: is this what we want?
       end
     end
 

--- a/spec/features/indexing_custom_document_spec.rb
+++ b/spec/features/indexing_custom_document_spec.rb
@@ -112,10 +112,6 @@ RSpec.describe 'Indexing Custom Document', type: :feature do
       expect(doc['extent_ssm'].first).to match(/^15\.0 linear feet/)
     end
 
-    it '#unitdate' do
-      expect(doc['unitdate_ssm'].first).to eq '1894-1992'
-    end
-
     it '#accessrestrict' do
       expect(doc['accessrestrict_ssm'].first).to eq 'No restrictions on access.'
     end
@@ -128,6 +124,14 @@ RSpec.describe 'Indexing Custom Document', type: :feature do
       expect(doc['access_subjects_ssim']).to include 'Fraternizing'
       expect(doc['names_ssim']).to include 'Root, William Webster, 1867-1932'
       expect(doc['places_ssim']).to include 'Mindanao Island (Philippines)'
+    end
+
+    it '#normalized_title' do
+      expect(doc['normalized_title_ssm'].first).to eq 'Alpha Omega Alpha Archives, 1894-1992'
+    end
+
+    it '#normalized_date' do
+      expect(doc['normalized_date_ssm'].first).to eq '1894-1992'
     end
 
     describe '#has_online_content' do
@@ -149,17 +153,11 @@ RSpec.describe 'Indexing Custom Document', type: :feature do
     describe '#date_range' do
       it 'includes an array of all the years in a particular unit-date range described in YYYY/YYYY format' do
         date_range_field = doc['date_range_sim']
-        expect(doc['unitdate_ssm']).to eq ['1894-1992'] # the field the range is derived from
         expect(date_range_field).to be_an Array
         expect(date_range_field.length).to eq 99
         expect(date_range_field.first).to eq '1894'
         expect(date_range_field.last).to eq '1992'
       end
-
-      # We don't have EADs in our fixtures that exhibit the following behaviors
-      it 'is nil for non normal dates'
-      it 'handles normal unitdates formatted as YYYY/YYYY when the years are the same'
-      it 'handles normal unitdates formatted as YYYY'
     end
 
     describe 'digital content' do

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Search results', type: :feature do
       within('#facets') do
         within('.blacklight-collection_sim') do
           expect(page).to have_css('h3 a', text: 'Collection')
-          expect(page).to have_css('li .facet-label', text: 'Alpha Omega Alpha Archives', visible: false)
+          expect(page).to have_css('li .facet-label', text: 'Alpha Omega Alpha Archives, 1894-1992', visible: false)
         end
 
         within('.blacklight-level_sim') do

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -246,6 +246,7 @@
           <unittitle>Series I: Administrative Records,</unittitle>
           <unitid>MS C 271.I</unitid>
           <unitdate normal="1902/1976" type="inclusive">1902-1976</unitdate>
+          <unitdate normal="1902/1976" type="bulk">1975-1976</unitdate>
         </did>
         <scopecontent id="aspace_00d4328c32ed5e54eac5c662aa45245a">
           <p>Administrative records include details materials directly related to the history and
@@ -584,7 +585,6 @@
           <unittitle>Series VII: Subject Files,</unittitle>
           <unitid>MS C 271.VII</unitid>
           <unitdate normal="1924/1955" type="inclusive">1924-1955</unitdate>
-          <unitdate normal="1944/1944" type="inclusive">1944</unitdate>
         </did>
         <accessrestrict><p>Restricted until 2018.</p></accessrestrict>
       </c>

--- a/spec/lib/arclight/indexer_spec.rb
+++ b/spec/lib/arclight/indexer_spec.rb
@@ -21,24 +21,24 @@ RSpec.describe Arclight::Indexer do
   describe '#add_collection_context_to_parent_fields' do
     context 'collection context' do
       it 'are appended to the existing parent fields' do
-        node = xml.xpath('//c').first
+        node = xml.at_xpath('//c')
         fields = indexer.additional_component_fields(node)
         expect(fields['parent_ssi']).to eq 'aoa271'
         expect(fields['parent_ssm']).to eq ['aoa271']
-        expect(fields['parent_unittitles_ssm']).to eq ['Alpha Omega Alpha Archives']
+        expect(fields['parent_unittitles_ssm']).to eq ['Alpha Omega Alpha Archives, 1894-1992']
       end
     end
   end
 
   describe '#add_count_of_child_compontents' do
     it 'adds the number of direct children' do
-      node = xml.xpath('//c[@id="aspace_563a320bb37d24a9e1e6f7bf95b52671"]').first
+      node = xml.at_xpath('//c[@id="aspace_563a320bb37d24a9e1e6f7bf95b52671"]')
       fields = indexer.additional_component_fields(node)
       expect(fields['child_component_count_isim']).to eq 25
     end
 
     it 'retunrs zero when the child has no components' do
-      node = xml.xpath('//c[@id="aspace_843e8f9f22bac69872d0802d6fffbb04"]').first
+      node = xml.at_xpath('//c[@id="aspace_843e8f9f22bac69872d0802d6fffbb04"]')
       fields = indexer.additional_component_fields(node)
       expect(fields['child_component_count_isim']).to eq 0
     end

--- a/spec/lib/arclight/normalized_date_spec.rb
+++ b/spec/lib/arclight/normalized_date_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Arclight::NormalizedDate do
+  subject(:normalized_date) { described_class.new(date_inclusive, date_bulk, date_other).to_s }
+
+  let(:date_inclusive) { '1990-2000' }
+  let(:date_bulk) { '1999-2005' }
+  let(:date_other) { nil }
+
+  context 'under normal conditions' do
+    it 'joins dates' do
+      expect(normalized_date).to eq '1990-2000, bulk 1999-2005'
+    end
+  end
+
+  context 'with special case dates' do
+    context 'multiples' do
+      let(:date_inclusive) { %w[1990-2000 2001-2002 2004] }
+      let(:date_bulk) { '1990-2004' }
+
+      it 'uses compressed joined years' do
+        expect(normalized_date).to eq '1990-2002, 2004, bulk 1990-2004'
+      end
+    end
+
+    context 'undated' do
+      let(:date_bulk) { 'n.d.' }
+
+      it 'do not normalized term "undated"' do
+        expect(normalized_date).to eq '1990-2000, bulk n.d.'
+      end
+    end
+
+    context 'circa' do
+      let(:date_bulk) { 'c.1995' }
+
+      it 'do not normalized term "circa"' do
+        expect(normalized_date).to eq '1990-2000, bulk c.1995'
+      end
+    end
+
+    context 'no bulk' do
+      let(:date_bulk) { nil }
+
+      it 'uses inclusive date only' do
+        expect(normalized_date).to eq '1990-2000'
+      end
+    end
+
+    context 'no inclusive or bulk but other' do
+      let(:date_inclusive) { nil }
+      let(:date_bulk) { nil }
+      let(:date_other) { 'n.d.' }
+
+      it 'uses other' do
+        expect(normalized_date).to eq 'n.d.'
+      end
+    end
+
+    context 'no inclusive but bulk' do
+      let(:date_inclusive) { nil }
+
+      it 'does not know what to do' do
+        expect(normalized_date).to be_nil
+      end
+    end
+
+    context 'no information' do
+      let(:date_inclusive) { nil }
+      let(:date_bulk) { nil }
+
+      it 'does not know what to do' do
+        expect(normalized_date).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/arclight/normalized_title_spec.rb
+++ b/spec/lib/arclight/normalized_title_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Arclight::NormalizedTitle do
+  subject(:normalized_title) { described_class.new(title, date, id).to_s }
+
+  let(:title) { 'My Title' }
+  let(:date) { '1990-2000' }
+  let(:id) { '1234' }
+
+  context 'under normal conditions' do
+    it 'joins the title and date' do
+      expect(normalized_title).to eq 'My Title, 1990-2000'
+    end
+  end
+
+  context 'with special case titles' do
+    context 'punctuated titles' do
+      let(:title) { 'My, Title' }
+
+      it 'joins the title as-is and date' do
+        expect(normalized_title).to eq 'My, Title, 1990-2000'
+      end
+    end
+
+    context 'buggy title (comma at end)' do
+      let(:title) { 'My Title,' }
+
+      it 'cleans up the title and joins with the date' do
+        expect(normalized_title).to eq 'My Title, 1990-2000'
+      end
+    end
+
+    context 'buggy title (quoted comma at end)' do
+      let(:title) { '"My Title,"' }
+
+      it 'is buggy but we allow it' do
+        expect(normalized_title).to eq '"My Title,", 1990-2000'
+      end
+    end
+
+    context 'spacey title' do
+      let(:title) { '   My Title   ' }
+
+      it 'cleans up the title and joins with the date' do
+        expect(normalized_title).to eq 'My Title, 1990-2000'
+      end
+    end
+
+    context 'blank title' do
+      let(:title) { '  ' }
+
+      it 'uses only the date' do
+        expect(normalized_title).to eq date
+      end
+    end
+
+    context 'missing title' do
+      let(:title) { nil }
+
+      it 'uses only the date' do
+        expect(normalized_title).to eq date
+      end
+    end
+  end
+
+  context 'with special case dates' do
+    context 'spacey date' do
+      let(:date) { '  1990-2000  ' }
+
+      it 'joins the title and date' do
+        expect(normalized_title).to eq 'My Title, 1990-2000'
+      end
+    end
+
+    context 'just n.d.' do
+      let(:date) { 'n.d.' }
+
+      it 'joins the title and date as-is' do
+        expect(normalized_title).to eq 'My Title, n.d.'
+      end
+    end
+
+    context 'extra n.d.' do
+      let(:date) { '1990-2000, bulk n.d.' }
+
+      it 'joins the title and date as-is' do
+        expect(normalized_title).to eq 'My Title, 1990-2000, bulk n.d.'
+      end
+    end
+
+    context 'extra year/range' do
+      let(:date) { '1956-1994, bulk 1968-1993' }
+
+      it 'joins the title and date as-is' do
+        expect(normalized_title).to eq 'My Title, 1956-1994, bulk 1968-1993'
+      end
+    end
+
+    context 'blank date' do
+      let(:date) { '   ' }
+
+      it 'uses only the title' do
+        expect(normalized_title).to eq title
+      end
+    end
+
+    context 'missing date' do
+      let(:date) { nil }
+
+      it 'uses only the title' do
+        expect(normalized_title).to eq title
+      end
+    end
+  end
+
+  context 'no title or date' do
+    let(:title) { nil }
+    let(:date) { nil }
+
+    it 'uses the id' do
+      expect(normalized_title).to eq id
+    end
+  end
+
+  context 'no information' do
+    let(:title) { nil }
+    let(:date) { nil }
+    let(:id) { nil }
+
+    it 'does not know what to do' do
+      expect(normalized_title).to eq ''
+    end
+  end
+end

--- a/spec/models/concerns/arclight/solr_document_spec.rb
+++ b/spec/models/concerns/arclight/solr_document_spec.rb
@@ -68,4 +68,20 @@ RSpec.describe Arclight::SolrDocument do
       end
     end
   end
+
+  describe '#normalize_title' do
+    let(:document) { SolrDocument.new(normalized_title_ssm: 'My Title, 1990-2000') }
+
+    it 'uses the normalized title from index-time' do
+      expect(document.normalized_title).to eq 'My Title, 1990-2000'
+    end
+  end
+
+  describe '#normalize_date' do
+    let(:document) { SolrDocument.new(normalized_date_ssm: '1990-2000') }
+
+    it 'uses the normalized date from index-time' do
+      expect(document.normalized_date).to eq '1990-2000'
+    end
+  end
 end

--- a/spec/presenters/arclight/index_presenter_spec.rb
+++ b/spec/presenters/arclight/index_presenter_spec.rb
@@ -13,8 +13,7 @@ describe Arclight::IndexPresenter, type: :presenter do
 
   let(:document) do
     SolrDocument.new(id: 1,
-                     'title_ssm' => ['My Title'],
-                     'unitdate_ssm' => ['1900-2000'])
+                     'normalized_title_ssm' => 'My Title, 1900-2000')
   end
 
   before do
@@ -22,36 +21,12 @@ describe Arclight::IndexPresenter, type: :presenter do
       controller: instance_double('Controller', params: {}, session: {}),
       default_document_index_view_type: 'index'
     )
-    config.index.title_field = :title_ssm
+    config.index.title_field = :normalized_title_ssm
   end
 
   describe '#label' do
-    context 'with a title that ends in a comma' do
-      it 'joins the title and date with a space' do
-        expect(presenter.label('The Title,')).to eq 'The Title, 1900-2000'
-      end
-      context 'without a date' do
-        let(:document) do
-          SolrDocument.new(id: 1, 'title_ssm' => ['My Title,'])
-        end
-
-        it 'strips the trailing comma' do
-          expect(presenter.label('The Title,')).to eq 'The Title'
-        end
-      end
-    end
-
-    context 'when a title that does not end in a comma' do
-      it 'joins the title and date with a comma+space' do
-        expect(presenter.label('The Title')).to eq 'The Title, 1900-2000'
-      end
-    end
-
-    context 'when a title is missing' do
-      it 'uses only the date' do
-        expect(presenter.label('   ')).to eq '1900-2000'
-        expect(presenter.label(nil)).to eq '1900-2000'
-      end
+    it 'uses normalized title' do
+      expect(presenter.label).to eq 'My Title, 1900-2000'
     end
   end
 end

--- a/spec/presenters/arclight/show_presenter_spec.rb
+++ b/spec/presenters/arclight/show_presenter_spec.rb
@@ -12,58 +12,16 @@ describe Arclight::ShowPresenter, type: :presenter do
 
   let(:document) do
     SolrDocument.new(id: 1,
-                     'title_ssm' => ['My Title'],
-                     'unitdate_ssm' => ['1900-2000'])
+                     'normalized_title_ssm' => ['My Title, 1900-2000'])
   end
 
   before do
-    config.show.title_field = :title_ssm
+    config.show.title_field = :normalized_title_ssm
   end
 
   describe '#heading' do
-    it 'appends the date' do
+    it 'uses normalized title' do
       expect(presenter.heading).to eq 'My Title, 1900-2000'
-    end
-
-    context 'documents without dates' do
-      let(:document) { SolrDocument.new(id: 1, 'title_ssm' => ['My Title']) }
-
-      it 'only renders the title' do
-        expect(presenter.heading).to eq 'My Title'
-      end
-    end
-
-    context 'titles with commas' do
-      let(:document) do
-        SolrDocument.new(id: 1,
-                         'title_ssm' => ['My Title,'],
-                         'unitdate_ssm' => ['1900-2000'])
-      end
-
-      it 'does not duplicate commas' do
-        expect(presenter.heading).to eq 'My Title, 1900-2000'
-      end
-    end
-
-    context 'no title' do
-      let(:document) do
-        SolrDocument.new(id: 1,
-                         'unitdate_ssm' => ['1900-2000'])
-      end
-
-      it 'uses the date only' do
-        expect(presenter.heading).to eq '1900-2000'
-      end
-    end
-
-    context 'no title or date' do
-      let(:document) do
-        SolrDocument.new(id: 1)
-      end
-
-      it 'uses the document id' do
-        expect(presenter.heading).to eq '1'
-      end
     end
   end
 


### PR DESCRIPTION
This PR fixes #319.

It uses the `Arclight::NormalizeTitle` throughtout the indexer and changes the default title to the `normalized_title_ssm` field.  Titles are now "Title, Date" where the date follows rules in http://www2.archivists.org/standards/DACS/part_I/chapter_2/4_date. Some examples include:

* My Title
* 1994-1999
* My TItle, n.d.
* My Title, c.1999
* My TItle, 1999-2000
* My Title, 1999-2000, bulk 1995-2005

Some notes about this PR:

* It rebuilds the `parent` fields that `solr_ead` generates as _both_ their ids and titles are not normalized as we want them to be. This code is in `solr_ead_indexer_ext.rb` and it replaces much of what was there before.

![screen shot 2017-05-16 at 4 11 02 pm](https://cloud.githubusercontent.com/assets/1861171/26132022/4e311ffa-3a52-11e7-9136-5f76c3fc77d4.png)
^^^ both ids and titles are normalized ^^^
* It removes the `document.unitdate` in the solr document concern. There's now a `normalized_date` for that information.
* It removes the `normalized_date_range` field and replaces it with a `NormalizeDate` class which follows the DACS rules better.
* I didn't remove `title_ssm` and `unitdate_ssm` from the indexer -- these are the raw text values from those elements and they may be useful at some point.
* We're only working with the `unitdate TYPE` attribute --  I'm not looking at the `unitdate CERTAINTY` attribute for example.

### Collection facet

![screen shot 2017-05-17 at 11 13 38 am](https://cloud.githubusercontent.com/assets/1861171/26169278/e931b7fe-3af1-11e7-9371-55846eda0298.png)

### Examples of Contents on Collection show page
![screen shot 2017-05-17 at 11 14 43 am](https://cloud.githubusercontent.com/assets/1861171/26169335/13f2085e-3af2-11e7-8f6e-3b7c0dfc0210.png)

![screen shot 2017-05-17 at 11 06 25 am](https://cloud.githubusercontent.com/assets/1861171/26168983/fb155436-3af0-11e7-871e-d9924d4dc058.png)

