### PR TITLE
Add a rake task to destroy all index documents.

### DIFF
--- a/lib/arclight/solr_ead_indexer_ext.rb
+++ b/lib/arclight/solr_ead_indexer_ext.rb
@@ -15,6 +15,11 @@ module Arclight
       solr_doc
     end
 
+    def delete_all
+      solr.delete_by_query('*:*')
+      solr.commit
+    end
+
     private
 
     ##

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -32,6 +32,13 @@ namespace :arclight do
       system("rake arclight:index FILE=#{file}")
     end
   end
+
+  desc'Destroy all documents in the index'
+  task :destroy_index_docs do
+    puts 'Deleting all documents from index...'
+    indexer = load_indexer
+    indexer.delete_all
+  end
 end
 
 def load_indexer

--- a/spec/lib/arclight/indexer_spec.rb
+++ b/spec/lib/arclight/indexer_spec.rb
@@ -43,4 +43,18 @@ RSpec.describe Arclight::Indexer do
       expect(fields['child_component_count_isim']).to eq 0
     end
   end
+
+  describe 'delete_all' do
+    before do
+      expect(indexer).to receive_messages(solr: solr_client)
+    end
+
+    let(:solr_client) { instance_spy('SolrClient') }
+
+    it 'sends the delete all query to solr and commits' do
+      indexer.delete_all
+      expect(solr_client).to have_received(:delete_by_query).with('*:*')
+      expect(solr_client).to have_receive(:commit)
+    end
+  end
 end


### PR DESCRIPTION
We can use this in the demo app to clear out docs before indexing (which will help us w/ the documents w/ the bad IDs).