### PR TITLE
support for field-based searches

### DIFF
--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -120,13 +120,33 @@ class CatalogController < ApplicationController
     # This one uses all the defaults set by the solr request handler. Which
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
-    config.add_search_field 'all_fields', label: 'All Fields'
+    config.add_search_field 'all_fields', label: 'All Fields' do |field|
+      field.include_in_simple_select = true
+    end
 
     config.add_search_field 'within_collection' do |field|
       field.include_in_simple_select = false
       field.solr_parameters = {
         fq: '-level_sim:Collection'
       }
+    end
+
+    # Field-based searches. We have registered handlers in the Solr configuration
+    # so we have Blacklight use the `qt` parameter to invoke them
+    config.add_search_field 'keyword', label: 'Keyword' do |field|
+      field.qt = 'search' # default
+    end
+    config.add_search_field 'name', label: 'Name' do |field|
+      field.qt = 'name_search'
+    end
+    config.add_search_field 'place', label: 'Place' do |field|
+      field.qt = 'place_search'
+    end
+    config.add_search_field 'subject', label: 'Subject' do |field|
+      field.qt = 'subject_search'
+    end
+    config.add_search_field 'title', label: 'Title' do |field|
+      field.qt = 'title_search'
     end
 
     # "sort results by" select (pulldown)
@@ -173,7 +193,7 @@ class CatalogController < ApplicationController
     config.show.component_metadata_partials = [
       :component_field
     ]
-    
+
     # Component Show Page - Metadata Section
     config.add_component_field 'containers_ssim', label: 'Containers'
     config.add_component_field 'abstract_ssm', label: 'Abstract'

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -16,10 +16,10 @@
  limitations under the License.
 -->
 
-<!--  
+<!--
  This is the Solr schema file. This file should be named "schema.xml" and
  should be in the conf directory under the solr home
- (i.e. ./solr/conf/schema.xml by default) 
+ (i.e. ./solr/conf/schema.xml by default)
  or located where the classloader for the Solr webapp can find it.
 
  This example schema is the recommended starting point for users.
@@ -51,7 +51,7 @@
        version="1.4" is Solr's version number for the schema syntax and semantics.  It should
        not normally be changed by applications.
        1.0: multiValued attribute did not exist, all fields are multiValued by nature
-       1.1: multiValued attribute introduced, false by default 
+       1.1: multiValued attribute introduced, false by default
        1.2: omitTermFreqAndPositions attribute introduced, true by default except for text fields.
        1.3: removed optional field compress feature
        1.4: default auto-phrase (QueryParser feature) to off
@@ -88,7 +88,7 @@
        - If sortMissingLast="false" and sortMissingFirst="false" (the default),
          then default lucene sorting will be used which places docs without the
          field first in an ascending sort and last in a descending sort.
-    -->    
+    -->
 
     <!--
       Default numeric field types. For faster range queries, consider the tint/tfloat/tlong/tdouble types.
@@ -115,7 +115,7 @@
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
-         http://www.w3.org/TR/xmlschema-2/#dateTime    
+         http://www.w3.org/TR/xmlschema-2/#dateTime
          The trailing "Z" designates UTC time and is mandatory.
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
          All other components are mandatory.
@@ -130,7 +130,7 @@
                NOW/DAY+6MONTHS+3DAYS
                   ... 6 months and 3 days in the future from the start of
                       the current day
-                      
+
          Consult the DateField javadocs for more information.
 
          Note: For faster range queries, consider the tdate type
@@ -142,11 +142,11 @@
 
     <!-- The "RandomSortField" is not used to store or search any
          data.  You can declare fields of this type it in your schema
-         to generate pseudo-random orderings of your docs for sorting 
-         purposes.  The ordering is generated based on the field name 
+         to generate pseudo-random orderings of your docs for sorting
+         purposes.  The ordering is generated based on the field name
          and the version of the index, As long as the index version
          remains unchanged, and the same field name is reused,
-         the ordering of the docs will be consistent.  
+         the ordering of the docs will be consistent.
          If you want different psuedo-random orderings of documents,
          for the same version of the index, use a dynamicField and
          change the name
@@ -351,13 +351,13 @@
         <filter class="solr.TrimFilterFactory" />
         <!-- The PatternReplaceFilter gives you the flexibility to use
              Java Regular expression to replace any sequence of characters
-             matching a pattern with an arbitrary replacement string, 
+             matching a pattern with an arbitrary replacement string,
              which may include back references to portions of the original
              string matched by the pattern.
-             
+
              See the Java Regular Expression documentation for more
              information on pattern and replacement string syntax.
-             
+
              http://java.sun.com/j2se/1.5.0/docs/api/java/util/regex/package-summary.html
           -->
         <filter class="solr.PatternReplaceFilterFactory"
@@ -365,7 +365,7 @@
         />
       </analyzer>
     </fieldType>
-    
+
     <fieldtype name="phonetic" stored="false" indexed="true" class="solr.TextField" >
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -379,7 +379,7 @@
         <!--
         The DelimitedPayloadTokenFilter can put payloads on tokens... for example,
         a token of "foo|1.4"  would be indexed as "foo" with a payload of 1.4f
-        Attributes of the DelimitedPayloadTokenFilterFactory : 
+        Attributes of the DelimitedPayloadTokenFilterFactory :
          "delimiter" - a one character delimiter. Default is | (pipe)
 	 "encoder" - how to encode the following value into a playload
 	    float -> org.apache.lucene.analysis.payloads.FloatEncoder,
@@ -406,12 +406,12 @@
     </fieldType>
 
     <!-- since fields of this type are by default not stored or indexed,
-         any data added to them will be ignored outright.  --> 
+         any data added to them will be ignored outright.  -->
     <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
 
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if 
+      definition is created matching *___<typename>.  Alternately, if
       subFieldSuffix is defined, that is used to create the subFields.
       Example: if subFieldType="double", then the coordinates would be
         indexed in fields myloc_0___double,myloc_1___double.
@@ -436,7 +436,7 @@
  <fields>
    <!-- Valid attributes for fields:
      name: mandatory - the name for the field
-     type: mandatory - the name of a previously defined type from the 
+     type: mandatory - the name of a previously defined type from the
        <types> section
      indexed: true if this field should be indexed (searchable or sortable)
      stored: true if this field should be retrievable
@@ -449,9 +449,9 @@
        given field.
        When using MoreLikeThis, fields used for similarity should be
        stored for best performance.
-     termPositions: Store position information with the term vector.  
+     termPositions: Store position information with the term vector.
        This will increase storage costs.
-     termOffsets: Store offset information with the term vector. This 
+     termOffsets: Store offset information with the term vector. This
        will increase storage costs.
      default: a value that should be used if no value is specified
        when adding a document.
@@ -505,10 +505,10 @@
    <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
    <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
 
-   <!-- uncomment the following to ignore any fields that don't already match an existing 
-        field name or dynamic field, rather than reporting them as an error. 
-        alternately, change the type="ignored" to some other type e.g. "text" if you want 
-        unknown fields indexed and/or stored by default --> 
+   <!-- uncomment the following to ignore any fields that don't already match an existing
+        field name or dynamic field, rather than reporting them as an error.
+        alternately, change the type="ignored" to some other type e.g. "text" if you want
+        unknown fields indexed and/or stored by default -->
    <!--dynamicField name="*" type="ignored" multiValued="true" /-->
 
    <dynamicField name="*_teim"  type="text_en"   stored="false" indexed="true"  multiValued="true"  />
@@ -522,10 +522,10 @@
    <dynamicField name="*_bsi"   type="boolean"   stored="true"  indexed="true"  multiValued="false" />
    <dynamicField name="*_isim"  type="int"       stored="true"  indexed="true"  multiValued="true"  />
    <dynamicField name="*_ii"    type="int"       stored="false" indexed="true"  multiValued="false" />
-   
+
  </fields>
 
- <!-- Field to use to determine and enforce document uniqueness. 
+ <!-- Field to use to determine and enforce document uniqueness.
       Unless this field is marked with required="false", it will be a required field
    -->
  <uniqueKey>id</uniqueKey>
@@ -540,17 +540,29 @@
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->
    <!-- Copy Fields -->
+
+   <!-- field-based searches -->
+   <copyField source="title_ssm" dest="title_teim"/>
+   <copyField source="places_ssm" dest="place_teim"/>
+   <copyField source="names_ssim" dest="name_teim"/>
+   <copyField source="access_subjects_ssim" dest="subject_teim"/>
+
+   <!-- The catch all `text` field -->
+   <copyField source="title_ssm" dest="text"/>
+   <copyField source="scopecontent_ssm" dest="text"/>
+   <copyField source="abstract_ssm" dest="text"/>
+   <!-- TODO: we probably need to add more fields here -->
    <!-- Indexed fields -->
    <copyField source="*i" dest="text"/>
    <copyField source="*im" dest="text"/>
-  
+
    <!-- unstemmed fields -->
    <!-- <copyField source="title_t" dest="title_unstem_search"/> -->
-   
+
    <!-- sort fields -->
    <!-- <copyField source="pub_date" dest="pub_date_sort"/> -->
-   
-        
+
+
    <!-- spellcheck fields -->
    <!-- default spell check;  should match fields for default request handler -->
    <!-- it won't work with a copy of a copy field -->
@@ -558,17 +570,17 @@
 
    <!-- for suggestions -->
    <copyField source="*_t" dest="suggest"/>
-   
-   <!-- Above, multiple source fields are copied to the [text] field. 
-	  Another way to map multiple source fields to the same 
-	  destination field is to use the dynamic field syntax. 
+
+   <!-- Above, multiple source fields are copied to the [text] field.
+	  Another way to map multiple source fields to the same
+	  destination field is to use the dynamic field syntax.
 	  copyField also supports a maxChars to copy setting.  -->
-	   
+
    <!-- <copyField source="*_t" dest="text" maxChars="3000"/> -->
 
    <!-- copy name to alphaNameSort, a field designed for sorting by name -->
    <!-- <copyField source="name" dest="alphaNameSort"/> -->
- 
+
 
  <!-- Similarity is the scoring routine for each document vs. a query.
       A custom similarity may be specified here, but the default is fine

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -94,7 +94,6 @@
        <int name="ps">3</int>
        <float name="tie">0.01</float>
 
-       <!-- NOT using marc_display because it is large and will slow things down for search results -->
        <str name="fl">
          id,
          score,
@@ -138,62 +137,130 @@
        <str name="spellcheck.count">5</str>
 
      </lst>
-    <!-- In addition to defaults, "appends" params can be specified
-         to identify values which should be appended to the list of
-         multi-val params from the query (or the existing "defaults").
-      -->
-    <!-- In this example, the param "fq=instock:true" would be appended to
-         any query time fq params the user may specify, as a mechanism for
-         partitioning the index, independent of any user selected filtering
-         that may also be desired (perhaps as a result of faceted searching).
-
-         NOTE: there is *absolutely* nothing a client can do to prevent these
-         "appends" values from being used, so don't use this mechanism
-         unless you are sure you always want it.
-      -->
-    <!--
-       <lst name="appends">
-         <str name="fq">inStock:true</str>
-       </lst>
-      -->
-    <!-- "invariants" are a way of letting the Solr maintainer lock down
-         the options available to Solr clients.  Any params values
-         specified here are used regardless of what values may be specified
-         in either the query, the "defaults", or the "appends" params.
-
-         In this example, the facet.field and facet.query params would
-         be fixed, limiting the facets clients can use.  Faceting is
-         not turned on by default - but if the client does specify
-         facet=true in the request, these are the only facets they
-         will be able to see counts for; regardless of what other
-         facet.field or facet.query params they may specify.
-
-         NOTE: there is *absolutely* nothing a client can do to prevent these
-         "invariants" values from being used, so don't use this mechanism
-         unless you are sure you always want it.
-      -->
-    <!--
-       <lst name="invariants">
-         <str name="facet.field">cat</str>
-         <str name="facet.field">manu_exact</str>
-         <str name="facet.query">price:[* TO 500]</str>
-         <str name="facet.query">price:[500 TO *]</str>
-       </lst>
-      -->
-    <!-- If the default list of SearchComponents is not desired, that
-         list can either be overridden completely, or components can be
-         prepended or appended to the default list.  (see below)
-      -->
-    <!--
-       <arr name="components">
-         <str>nameOfCustomComponent1</str>
-         <str>nameOfCustomComponent2</str>
-       </arr>
-      -->
     <arr name="last-components">
       <str>spellcheck</str>
     </arr>
+  </requestHandler>
 
+  <!-- Field-based searches -->
+  <requestHandler name="name_search" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="defType">edismax</str>
+      <str name="echoParams">explicit</str>
+      <int name="rows">10</int>
+      <str name="q.alt">*:*</str>
+      <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+      <str name="df">name_teim</str>
+      <str name="q.op">AND</str>
+
+      <str name="qf">
+        name_teim
+      </str>
+      <str name="pf">
+        name_teim
+      </str>
+
+      <str name="fl">*</str>
+      <str name="facet">true</str>
+      <str name="facet.mincount">1</str>
+      <str name="facet.field">level_sim</str>
+      <str name="facet.field">creator_sim</str>
+      <str name="facet.field">date_range_sim</str>
+      <str name="facet.field">names_sim</str>
+      <str name="facet.field">geogname_sim</str>
+      <str name="facet.field">access_subjects_sim</str>
+      <str name="facet.field">repository_sim</str>
+    </lst>
+  </requestHandler>
+
+  <requestHandler name="place_search" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="defType">edismax</str>
+      <str name="echoParams">explicit</str>
+      <int name="rows">10</int>
+      <str name="q.alt">*:*</str>
+      <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+      <str name="df">place_teim</str>
+      <str name="q.op">AND</str>
+
+      <str name="qf">
+        place_teim
+      </str>
+      <str name="pf">
+        place_teim
+      </str>
+
+      <str name="fl">*</str>
+      <str name="facet">true</str>
+      <str name="facet.mincount">1</str>
+      <str name="facet.field">level_sim</str>
+      <str name="facet.field">creator_sim</str>
+      <str name="facet.field">date_range_sim</str>
+      <str name="facet.field">names_sim</str>
+      <str name="facet.field">geogname_sim</str>
+      <str name="facet.field">access_subjects_sim</str>
+      <str name="facet.field">repository_sim</str>
+    </lst>
+  </requestHandler>
+
+  <requestHandler name="subject_search" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="defType">edismax</str>
+      <str name="echoParams">explicit</str>
+      <int name="rows">10</int>
+      <str name="q.alt">*:*</str>
+      <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+      <str name="df">subject_teim</str>
+      <str name="q.op">AND</str>
+
+      <str name="qf">
+        subject_teim
+      </str>
+      <str name="pf">
+        subject_teim
+      </str>
+
+      <str name="fl">*</str>
+      <str name="facet">true</str>
+      <str name="facet.mincount">1</str>
+      <str name="facet.field">level_sim</str>
+      <str name="facet.field">creator_sim</str>
+      <str name="facet.field">date_range_sim</str>
+      <str name="facet.field">names_sim</str>
+      <str name="facet.field">geogname_sim</str>
+      <str name="facet.field">access_subjects_sim</str>
+      <str name="facet.field">repository_sim</str>
+    </lst>
+  </requestHandler>
+
+  <requestHandler name="title_search" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="defType">edismax</str>
+      <str name="echoParams">explicit</str>
+      <int name="rows">10</int>
+      <str name="q.alt">*:*</str>
+      <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+      <str name="df">title_teim</str>
+      <str name="q.op">AND</str>
+
+      <str name="qf">
+        title_teim
+      </str>
+      <str name="pf">
+        title_teim
+      </str>
+
+      <str name="fl">*</str>
+      <str name="facet">true</str>
+      <str name="facet.mincount">1</str>
+      <str name="facet.field">level_sim</str>
+      <str name="facet.field">creator_sim</str>
+      <str name="facet.field">date_range_sim</str>
+      <str name="facet.field">names_sim</str>
+      <str name="facet.field">geogname_sim</str>
+      <str name="facet.field">access_subjects_sim</str>
+      <str name="facet.field">repository_sim</str>
+    </lst>
   </requestHandler>
 
   <!-- for requests to get a single document; use id=666 instead of q=id:666 -->

--- a/spec/features/fielded_search_results_spec.rb
+++ b/spec/features/fielded_search_results_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Field-based search results', type: :feature do
+  describe 'searches by' do
+    it '#all_fields' do
+      visit search_catalog_path q: 'a brief account', search_field: 'all_fields'
+      within('.document-position-0') do
+        expect(page).to have_css '.index_title', text: /A brief account/
+      end
+    end
+
+    it '#keyword' do
+      visit search_catalog_path q: 'a brief account', search_field: 'keyword'
+      within('.document-position-0') do
+        expect(page).to have_css '.index_title', text: /A brief account/
+      end
+    end
+
+    it '#name' do
+      visit search_catalog_path q: 'root', search_field: 'name'
+      within('.document-position-0') do
+        expect(page).to have_css '.index_title', text: /Alpha Omega Alpha Archives/
+      end
+    end
+
+    it '#place' do
+      visit search_catalog_path q: 'island', search_field: 'place'
+      within('.document-position-0') do
+        expect(page).to have_css '.index_title', text: /Alpha Omega Alpha Archives/
+      end
+    end
+
+    it '#subject' do
+      visit search_catalog_path q: 'medicine', search_field: 'subject'
+      within('.document-position-0') do
+        expect(page).to have_css '.index_title', text: /Alpha Omega Alpha Archives/
+      end
+    end
+
+    it '#title' do
+      visit search_catalog_path q: 'motto', search_field: 'title'
+      within('.document-position-0') do
+        expect(page).to have_css '.index_title', text: /Plans for motto/
+      end
+      within('.document-position-1') do
+        expect(page).to have_css '.index_title', text: /Dr. Root and L. Raymond Higgins/
+      end
+    end
+  end
+end

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe 'Home Page', type: :feature do
   it 'does not have a search-navbar' do
     expect(page).not_to have_css '#search-navbar'
   end
+  context 'search dropdown' do
+    it 'has all fields' do
+      within('.search-field') do
+        expect(page).to have_css 'option', text: 'All Fields'
+      end
+    end
+    it 'has several fielded' do
+      within('.search-field') do
+        expect(page).to have_css 'option', text: 'Keyword'
+        expect(page).to have_css 'option', text: 'Name'
+        expect(page).to have_css 'option', text: 'Place'
+        expect(page).to have_css 'option', text: 'Subject'
+        expect(page).to have_css 'option', text: 'Title'
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #334 and is connected to #197.  It creates some new `*_teim` fields for the field-based searches in the schema, adds dedicated handlers for each of the search types, and then registers the options with Blacklight in catalog controller. It also adds the abstract and scope and content fields to the catch-all `text` field (there will be a new ticket that addresses exactly which fields we want searched for the "All fields" search).

Notes:
* I used `*` for the `fl` parameters in the field-based handlers. We can restrict those but I was hoping we could do it in a way that wouldn't have those fields duplicated in each of the handlers. I dunno if that's possible. Can you easily inherit parameters from a single place?
* Sorry about the whitespace changes in `schema.xml` -- my editor did that -- the content changes are the new `copyField` elements.
* I added the tests for the presence of the pulldown in the home page spec, and a new feature spec for search results.

![screen shot 2017-05-17 at 2 16 01 pm](https://cloud.githubusercontent.com/assets/1861171/26176553/63a2e92c-3b0b-11e7-8dd7-58cfcf5a130a.png)
