### PR TITLE
Updates solrconfig/schema for autocomplete.

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -569,7 +569,12 @@
    <copyField source="*_t" dest="spell"/>
 
    <!-- for suggestions -->
-   <copyField source="*_t" dest="suggest"/>
+   <copyField source="title_ssm" dest="suggest"/>
+   <copyField source="collection_sim" dest="suggest"/>
+   <copyField source="names_ssim" dest="suggest"/>
+   <copyField source="repository_sim" dest="suggest"/>
+   <copyField source="places_ssim" dest="suggest"/>
+   <copyField source="access_subjects_ssim" dest="suggest"/>
 
    <!-- Above, multiple source fields are copied to the [text] field.
 	  Another way to map multiple source fields to the same

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -362,8 +362,10 @@
   <searchComponent name="suggest" class="solr.SuggestComponent">
     <lst name="suggester">
       <str name="name">mySuggester</str>
-      <str name="lookupImpl">FuzzyLookupFactory</str>
-      <str name="suggestAnalyzerFieldType">textSuggest</str>
+      <str name="lookupImpl">AnalyzingInfixLookupFactory</str>
+      <str name="indexPath">suggester_infix_dir</str>
+      <str name="highlight">false</str>
+      <str name="suggestAnalyzerFieldType">text</str>
       <str name="buildOnCommit">true</str>
       <str name="field">suggest</str>
     </lst>

--- a/spec/features/autocomplete_spec.rb
+++ b/spec/features/autocomplete_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Autocomplete', type: :feature, js: true do
+  context 'site-wide search form' do
+    it 'is configured properly to allow non-prefix autocomplete' do
+      visit '/'
+      page.execute_script <<-EOF
+        $("[data-autocomplete-enabled]:visible").val("by-laws").trigger("input");
+        $("[data-autocomplete-enabled]:visible").typeahead("open");
+      EOF
+
+      within('.tt-menu') do
+        expect(page).to have_css('.tt-suggestion', text: 'constitution and by-laws', visible: true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #244 

This changes the default configuration (that ships w/ Blacklight) from using `FuzzyLookupFactory` to `AnalyzingInfixLookupFactory`.

The result of this is a non-prefixed search.  Using `FuzzyLookupFactory` you must type the beginning of a field.  This means that typing a person's first name (when their name is indexed `Last` `,` `First`) the autocomplete will not return the name.  Also, titles that begin in punctuation would have to have the punctuation typed first in-order to autocomplete.

Talking this over w/ @anarchivist, this does not seem to be the desired behavior for Arclight.

Instead I'm using the `AnalyzingInfixLookupFactory` which allows for non-prefixed autocompleting.

<img width="1031" alt="autocomplete" src="https://cloud.githubusercontent.com/assets/96776/26177611/354a3504-3b0f-11e7-9d73-d9fd3216af34.png">

Note: I'm going to break adding the autocomplete to the `Search within this collection` search form into a separate ticket.  This is because the autocomplete feature does not limit the results that are returned based on any context (even in other faceted search results).  I've done a bit of research and will add my findings to that ticket.