### PR TITLE
add slug-based routes for repositories

### DIFF
--- a/app/controllers/arclight/repositories_controller.rb
+++ b/app/controllers/arclight/repositories_controller.rb
@@ -8,6 +8,16 @@ module Arclight
       load_collection_counts
     end
 
+    def show
+      @repository = Arclight::Repository.find_by!(slug: params[:id])
+      search_service = Blacklight.repository_class.new(blacklight_config)
+      @response = search_service.search(
+        q: "level_sim:Collection repository_sim:\"#{@repository.name}\"",
+        rows: 100
+      )
+      @collections = @response.documents
+    end
+
     private
 
     def load_collection_counts

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -33,12 +33,17 @@ module ArclightHelper
     facets_from_request.find { |f| f.name == 'collection_sim' }.try(:items).try(:count)
   end
 
-  def repositories_active?
-    controller_name == 'repositories'
+  def on_repositories_show?
+    controller_name == 'repositories' && action_name == 'show'
   end
 
+  def on_repositories_index?
+    controller_name == 'repositories' && action_name == 'index'
+  end
+
+  # the Repositories menu item is only active on the Repositories index page
   def repositories_active_class
-    'active' if repositories_active?
+    'active' if on_repositories_index?
   end
 
   def fields_have_content?(document, field_accessor)
@@ -55,13 +60,6 @@ module ArclightHelper
     repos = facets_from_request.find { |f| f.name == 'repository_sim' }.try(:items)
     faceted = repos && repos.length == 1 && repos.first.value
     Arclight::Repository.find_by(name: repos.first.value) if faceted
-  end
-
-  # `link_to` to a search that facets on the given repository
-  #
-  # @param [String] `name` of the repository
-  def link_to_repository_facet(name)
-    link_to name, search_action_path(f: { 'repository_sim': [name] })
   end
 
   ##

--- a/app/views/arclight/repositories/_in_person_repository.html.erb
+++ b/app/views/arclight/repositories/_in_person_repository.html.erb
@@ -3,7 +3,7 @@
     <%= image_tag repository.thumbnail_url, alt: repository.name, class: 'img-fluid float-left' %>
   <% end %>
   <div>
-    <%= link_to_repository_facet repository.name %>
+    <%= link_to(repository.name, arclight_engine.repository_path(repository.slug)) %>
   </div>
 </div>
 <div class='al-in-person-repository-location'>

--- a/app/views/arclight/repositories/_repository.html.erb
+++ b/app/views/arclight/repositories/_repository.html.erb
@@ -7,7 +7,7 @@
 
       <div class="col-sm-12 col-lg-10 al-repository-information">
         <h2>
-          <%= link_to_repository_facet repository.name %>
+          <%= link_to(repository.name, arclight_engine.repository_path(repository.slug)) %>
         </h2>
         <div class='row no-gutters justify-content-md-center'>
           <div class='col-4 col-md-3 al-repository-contact'>
@@ -45,7 +45,7 @@
             <%= repository.description %>
           </div>
 
-          <% if repositories_active? %>
+          <% if on_repositories_index? %>
             <div class='col col-lg-2 al-repository-extra align-self-center hidden-md-down'>
               <div class='al-repository-extra-collection-count'>
                 <span class="al-repository-collection-count">

--- a/app/views/arclight/repositories/show.html.erb
+++ b/app/views/arclight/repositories/show.html.erb
@@ -1,0 +1,26 @@
+<%= render 'shared/breadcrumbs' %>
+<%= render @repository %>
+<h3>
+  <%= t('arclight.views.show.our_collections') %>
+</h3>
+<br/>
+<% @collections.each do |document| %>
+  <div class="col-md-12">
+    <div class='al-document-title-bar'>
+      <div class='row'>
+        <div class='col-8'>
+          <h5><%= link_to document.normalized_title, solr_document_path(document.id) %></h5>
+          <%= content_tag('div', class: 'al-document-abstract-or-scope', title: document.abstract_or_scope) do %>
+            <%= truncate(document.abstract_or_scope, length: 175) %>
+          <% end if document.abstract_or_scope %>
+        </div>
+        <% if document.unitid %>
+          <div class='col-4 text-right'>
+            <%= t(:'arclight.views.show.collection_id', id: document.unitid) %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+  <br/>
+<% end %>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -3,8 +3,12 @@
   <%= t('arclight.breadcrumb_separator') %>
   <% if collection_active? %>
     <%= t('arclight.routes.collections') %>
-  <% elsif repositories_active? %>
+  <% elsif on_repositories_index? %>
     <%= t('arclight.routes.repositories') %>
+  <% elsif on_repositories_show? %>
+    <%= link_to t('arclight.routes.repositories'), arclight_engine.repositories_path %>
+    <%= t('arclight.breadcrumb_separator') %>
+    <%= @repository.name %>
   <% else %>
     <%= t('arclight.routes.search_results') %>
   <% end %>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -46,6 +46,7 @@ en:
           admin_info_field: 'Administrative Information'
           component_field: 'About this %{level}'
           collection_context_field: 'Collection Context'
+        our_collections: 'Our Collections'
       repositories:
         number_of_collections:
           zero: 'No collections'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@
 
 Arclight::Engine.routes.draw do
   get 'collections' => 'catalog#index', defaults: { f: { level_sim: ['Collection'] } }, as: :collections
-  resources :repositories, only: %i[index], controller: 'arclight/repositories'
+  resources :repositories, only: %i[index show], controller: 'arclight/repositories'
 end

--- a/lib/arclight/repository.rb
+++ b/lib/arclight/repository.rb
@@ -76,5 +76,16 @@ module Arclight
         raise ArgumentError, 'Requires either slug or name parameters to find_by'
       end
     end
+
+    # Mimics ActiveRecord dynamic `find_by!` behavior for the slug or name
+    #
+    # @param [String] `slug` or `name` -- same as `find_by`
+    # @return [Repository]
+    # @raise [ActiveRecord::RecordNotFound] if cannot find repository
+    def self.find_by!(*args)
+      repository = find_by(*args)
+      raise ActiveRecord::RecordNotFound if repository.blank?
+      repository
+    end
   end
 end

--- a/spec/controllers/arclight/repositories_controller_spec.rb
+++ b/spec/controllers/arclight/repositories_controller_spec.rb
@@ -8,16 +8,35 @@ RSpec.describe Arclight::RepositoriesController, type: :controller do
     ENV['REPOSITORY_FILE'] = 'spec/fixtures/config/repositories.yml'
   end
 
-  it 'displays the repositories' do
-    get :index
-    expect(response).to be_success
+  context '#index' do
+    it 'displays the repositories' do
+      get :index
+      expect(response).to be_success
+    end
+
+    it 'assigns the view variable' do
+      get :index
+      repos = controller.instance_variable_get(:@repositories)
+      expect(repos).to be_an(Array)
+      expect(repos.first).to be_an(Arclight::Repository)
+      expect(repos.size).to eq 4
+    end
   end
 
-  it 'assigns the view variable' do
-    get :index
-    repos = controller.instance_variable_get(:@repositories)
-    expect(repos).to be_an(Array)
-    expect(repos.first).to be_an(Arclight::Repository)
-    expect(repos.size).to eq 4
+  context '#show' do
+    it 'looks up the repository detail page' do
+      get :show, params: { id: 'nlm' }
+      repo = controller.instance_variable_get(:@repository)
+      expect(repo).to be_an(Arclight::Repository)
+      expect(repo.slug).to eq 'nlm'
+      collections = controller.instance_variable_get(:@collections)
+      expect(collections.first).to be_an(SolrDocument)
+      expect(collections.first.unitid).to eq 'MS C 271'
+    end
+    it 'raises RecordNotFound if non-registered slug' do
+      expect { get :show, params: { id: 'not-registered' } }.to raise_error(
+        ActiveRecord::RecordNotFound
+      )
+    end
   end
 end

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -35,18 +35,38 @@ RSpec.describe ArclightHelper, type: :helper do
       end
     end
   end
-  describe '#repositories_active?' do
-    context 'with active repositories page' do
+  describe '#on_repositories_index?' do
+    before { allow(helper).to receive(:action_name).twice.and_return('index') }
+
+    context 'with repositories index' do
       it do
         allow(helper).to receive(:controller_name).twice.and_return('repositories')
-        expect(helper.repositories_active?).to eq true
+        expect(helper.on_repositories_index?).to eq true
         expect(helper.repositories_active_class).to eq 'active'
       end
     end
-    context 'without active repositories page' do
+    context 'without repositories index' do
       it do
         allow(helper).to receive(:controller_name).twice.and_return('NOT repositories')
-        expect(helper.repositories_active?).to eq false
+        expect(helper.on_repositories_index?).to eq false
+        expect(helper.repositories_active_class).to eq nil
+      end
+    end
+  end
+  describe '#on_repositories_show?' do
+    before { allow(helper).to receive(:action_name).twice.and_return('show') }
+
+    context 'with repositories show' do
+      it do
+        allow(helper).to receive(:controller_name).twice.and_return('repositories')
+        expect(helper.on_repositories_show?).to eq true
+        expect(helper.repositories_active_class).to eq nil
+      end
+    end
+    context 'without repositories show' do
+      it do
+        allow(helper).to receive(:controller_name).twice.and_return('NOT repositories')
+        expect(helper.on_repositories_show?).to eq false
         expect(helper.repositories_active_class).to eq nil
       end
     end
@@ -169,21 +189,6 @@ RSpec.describe ArclightHelper, type: :helper do
         expect(helper).to receive_messages(render_document_yolo_label: nil)
         helper.generic_render_document_field_label(field, 0, field: 1)
       end
-    end
-  end
-  describe '#link_to_repository_facet' do
-    let(:name) { 'My Repository' }
-    let(:path) { '/catalog?f=...' }
-
-    it 'links to an f query using search_action_path' do
-      allow(helper).to receive(:search_action_path)
-        .with(f: { 'repository_sim': [name] })
-        .and_return(path)
-      html = helper.link_to_repository_facet(name)
-      expect(helper).to have_received(:search_action_path)
-        .with(f: { 'repository_sim': [name] })
-      expect(html).to have_css('a @href', text: path)
-      expect(html).to have_css('a', text: name)
     end
   end
 end

--- a/spec/lib/arclight/repository_spec.rb
+++ b/spec/lib/arclight/repository_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe Arclight::Repository do
       expect(described_class.find_by(name: 'not_there')).to be_nil
       expect { described_class.find_by(name: nil) }.to raise_error(ArgumentError)
     end
+    it '#find_by!(slug)' do
+      expect(described_class.find_by!(slug: 'sample').slug).to eq 'sample'
+      expect { described_class.find_by!(slug: 'not_there') }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+    it '#find_by!(name)' do
+      expect(described_class.find_by!(name: 'My Repository').slug).to eq 'sample'
+      expect { described_class.find_by!(name: 'not_there') }.to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 
   context 'a single repository has data' do

--- a/spec/routing/arclight/repositories_spec.rb
+++ b/spec/routing/arclight/repositories_spec.rb
@@ -2,12 +2,21 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Vanity repositories route', type: :routing do
+RSpec.describe 'Vanity repositories routes', type: :routing do
   routes { Arclight::Engine.routes }
-  it 'routes to repositories display' do
-    expect(get: '/repositories').to route_to(
-      controller: 'arclight/repositories',
-      action: 'index'
-    )
+  context 'repositories' do
+    it '#index' do
+      expect(get: '/repositories').to route_to(
+        controller: 'arclight/repositories',
+        action: 'index'
+      )
+    end
+    it '#show' do
+      expect(get: '/repositories/my-slug').to route_to(
+        controller: 'arclight/repositories',
+        action: 'show',
+        id: 'my-slug'
+      )
+    end
   end
 end

--- a/spec/views/repositories/index.html.erb_spec.rb
+++ b/spec/views/repositories/index.html.erb_spec.rb
@@ -8,13 +8,21 @@ RSpec.describe 'arclight/repositories/index', type: :view do
   before do
     ENV['REPOSITORY_FILE'] = 'spec/fixtures/config/repositories.yml'
     assign(:repositories, test_data)
-    allow(view).to receive(:search_action_path).and_return('/catalog?f=...')
+    allow(view).to receive(:search_action_path).and_return('/')
+    allow(view).to receive(:on_repositories_index?).and_return(true)
+    allow(view).to receive(:on_repositories_show?).and_return(false)
   end
 
   context 'renders the three repository examples' do
     before { render }
     it 'has the header class' do
       expect(rendered).to have_css('.al-repositories', count: 1)
+    end
+    it 'has the proper title' do
+      within('.al-repository:nth-of-type(1)') do
+        expect(rendered).to have_css('h2', text: /My Repository/)
+        expect(rendered).to have_css('h2 a @href', text: '/repositories/sample')
+      end
     end
     it 'has the four sections' do
       expect(rendered).to have_css('.al-repository', count: 4)
@@ -59,12 +67,18 @@ RSpec.describe 'arclight/repositories/index', type: :view do
   end
   context 'switched extra content' do
     it 'shows on repositories page' do
-      allow(view).to receive(:repositories_active?).and_return(true)
       render
       expect(rendered).to have_css('.al-repository-extra', count: 4)
     end
+    it 'does not show on repositories detail page' do
+      assign(:repository, instance_double('repository', name: 'My Repository'))
+      allow(view).to receive(:on_repositories_index?).and_return(false)
+      allow(view).to receive(:on_repositories_show?).and_return(true)
+      render
+      expect(rendered).not_to have_css('.al-repository-extra')
+    end
     it 'does not show on search page' do
-      allow(view).to receive(:repositories_active?).and_return(false)
+      allow(view).to receive(:on_repositories_index?).and_return(false)
       render
       expect(rendered).not_to have_css('.al-repository-extra')
     end

--- a/spec/views/repositories/show.html.erb_spec.rb
+++ b/spec/views/repositories/show.html.erb_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'arclight/repositories/show', type: :view do
+  let(:test_data) { Arclight::Repository.find_by(slug: 'sample') }
+
+  before do
+    ENV['REPOSITORY_FILE'] = 'spec/fixtures/config/repositories.yml'
+    assign(:repository, test_data)
+    assign(:collections, [])
+    allow(view).to receive(:on_repositories_show?).and_return(true)
+  end
+
+  context 'renders a repository detail page' do
+    before { render }
+
+    it 'has the repository card' do
+      expect(rendered).to have_css('.al-repository h2', text: /My Repository/)
+    end
+    it 'has breadcrumbs' do
+      expect(rendered).to have_css('.al-search-breadcrumb', text: /My Repository/)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes #329. It adds slug based routes like `/repositories/my-slug`. Links for the repositories in the "In person" and "Repositories" view use the slug link. If the slug is not valid, then it throws `ActiveRecord::RecordNotFound`.

## The Repositories index page

Note that the Repository menu is marked "active"

![screen shot 2017-05-24 at 10 40 55 am](https://cloud.githubusercontent.com/assets/1861171/26417303/a864c2da-406d-11e7-87f3-1f8a76f72f51.png)

## The Repository show page

Note the breadcrumbs and both menu items are not marked active.

![screen shot 2017-05-24 at 10 41 05 am](https://cloud.githubusercontent.com/assets/1861171/26417314/b085bb22-406d-11e7-9cb5-eb85fbe881c5.png)


## Search results that has hits all from the same repository

Note both menu items are not marked active.

![screen shot 2017-05-24 at 10 41 24 am](https://cloud.githubusercontent.com/assets/1861171/26417317/b2611d7e-406d-11e7-95b9-e55008a476c1.png)

