### PR TITLE
adds a repository collection_count to our Repositories page

### DIFF
--- a/app/controllers/arclight/repositories_controller.rb
+++ b/app/controllers/arclight/repositories_controller.rb
@@ -5,6 +5,26 @@ module Arclight
   class RepositoriesController < ApplicationController
     def index
       @repositories = Arclight::Repository.all
+      load_collection_counts
+    end
+
+    private
+
+    def load_collection_counts
+      counts = fetch_collection_counts
+      @repositories.each do |repository|
+        repository.collection_count = counts[repository.name] || 0
+      end
+    end
+
+    def fetch_collection_counts
+      search_service = Blacklight.repository_class.new(blacklight_config)
+      results = search_service.search(
+        q: 'level_sim:Collection',
+        'facet.field': 'repository_sim',
+        rows: 0
+      )
+      Hash[*results.facet_fields['repository_sim']]
     end
   end
 end

--- a/app/views/arclight/repositories/_repository.html.erb
+++ b/app/views/arclight/repositories/_repository.html.erb
@@ -47,10 +47,10 @@
 
           <% if repositories_active? %>
             <div class='col col-lg-2 al-repository-extra align-self-center hidden-md-down'>
-              <!-- TODO: actually count the collections -->
               <div class='al-repository-extra-collection-count'>
-                <span class="al-repository-collection-count">9999</span>
-                 collections
+                <span class="al-repository-collection-count">
+                  <%= t(:'arclight.views.repositories.number_of_collections', count: repository.collection_count) %>
+                </span>
                </div>
               <button type='button' class='btn btn-secondary btn-sm'>Learn more</button>
             </div>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -46,4 +46,9 @@ en:
           admin_info_field: 'Administrative Information'
           component_field: 'About this %{level}'
           collection_context_field: 'Collection Context'
+      repositories:
+        number_of_collections:
+          zero: 'No collections'
+          one: '1 collection'
+          other: '%{count} collections'
     breadcrumb_separator: ' » '

--- a/lib/arclight/repository.rb
+++ b/lib/arclight/repository.rb
@@ -21,7 +21,8 @@ module Arclight
                 contact_info
                 thumbnail_url
                 google_request_url
-                google_request_mappings].freeze
+                google_request_mappings
+                collection_count].freeze
 
     attr_accessor :slug, *FIELDS
 

--- a/spec/views/repositories/index.html.erb_spec.rb
+++ b/spec/views/repositories/index.html.erb_spec.rb
@@ -39,6 +39,23 @@ RSpec.describe 'arclight/repositories/index', type: :view do
     it 'handles a missing phone' do
       expect(rendered).to have_css('.al-repository-contact-info-phone', count: 2)
     end
+    context 'collection counts' do
+      it '0 collections' do
+        within('.al-repository-extra-collection-count') do
+          expect(rendered).to have_css('.al-repository-collection-count', text: 'No collections')
+        end
+      end
+      it '1 collection' do
+        within('.al-repository-extra-collection-count') do
+          expect(rendered).to have_css('.al-repository-collection-count', text: '1 collection')
+        end
+      end
+      it 'n collections' do
+        within('.al-repository-extra-collection-count') do
+          expect(rendered).to have_css('.al-repository-collection-count', text: '2 collections')
+        end
+      end
+    end
   end
   context 'switched extra content' do
     it 'shows on repositories page' do


### PR DESCRIPTION
This PR fixes #331. It uses an optimized synchronous query, which is fast, to fetch the counts and render the repositories page.

![screen shot 2017-05-19 at 3 03 36 pm](https://cloud.githubusercontent.com/assets/1861171/26268946/ad3614fa-3ca6-11e7-9b54-9b85bc4e5437.png)
