### PR TITLE
Update header_navbar markup to deal with side-scroll issue.

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -31,11 +31,9 @@
     </nav>
   </div>
 <% else %>
-  <div class='row bg-faded al-masthead'>
-    <div class='col'>
-      <div class="container">
-        <h1><%= t('arclight.masthead_heading') %></h1>
-      </div>
+  <div class='bg-faded al-masthead'>
+    <div class="container">
+      <h1><%= t('arclight.masthead_heading') %></h1>
     </div>
   </div>
   <div class="navbar-search navbar navbar-toggleable-sm bg-faded" role="navigation">


### PR DESCRIPTION
Fixes #345 


## Before (notice the side-scrollbar) 
<img width="1187" alt="before" src="https://cloud.githubusercontent.com/assets/96776/26326510/5a6f96f0-3ef0-11e7-91ec-1d1e9fda966d.png">

## After
<img width="1180" alt="after" src="https://cloud.githubusercontent.com/assets/96776/26326509/5a4e53b4-3ef0-11e7-8765-b87be22652ef.png">
