### PR TITLE
Update styling of inventory contents hierarchy

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy.scss
@@ -1,10 +1,86 @@
 .documents-hierarchy {
-  h3 {
+  .document-title-heading {
     font-size: $font-size-h5;
   }
 
-  article {
-    padding: 5px;
+  // Number of children badge & toggle
+  .al-hierarchy-children-status {
+    text-align: right;
+  }
+
+  .al-toggle-view-all {
+    color: $gray-light;
+
+    &:before {
+      color: $gray-light;
+      content: "\2022";
+      padding-right: 3px;
+    }
+  }
+
+  // Component title + children badge
+  .documentHeader {
+    border-bottom: $border-width dashed #ccc;
+    margin-bottom: ($spacer / 2);
+    margin-top: ($spacer * 2);
+  }
+
+  // Headings and text
+  .al-document-abstract-or-scope {
+    font-size: 0.85rem;
+    line-height: 1.25;
+  }
+
+  // Series level
+  .blacklight-series .document-title-heading,
+  .blacklight-otherlevel .document-title-heading {
+    font-size: $font-size-h5;
+    font-weight: 400;
+    margin-bottom: ($spacer / 2);
+
+    > a {
+      color: $gray-dark;
+    }
+  }
+
+  .blacklight-series {
+    // Additional for levels below series
+    .blacklight-subseries .document-title-heading,
+    .blacklight-file .document-title-heading,
+    .blacklight-otherlevel .document-title-heading {
+      font-size: $font-size-h6;
+
+      .documentHeader {
+        margin-top: $spacer;
+      }
+    }
+
+    // Icongraphy for each level
+    .blacklight-subseries .document-title-heading,
+    .al-hierarchy-level-1 .blacklight-file .document-title-heading,
+    .al-hierarchy-level-1 .blacklight-otherlevel .document-title-heading {
+      border-left: ($border-width * 2) solid #999;
+      padding-left: 10px;
+    }
+
+    .al-hierarchy-level-2 .document-title-heading,
+    .al-hierarchy-level-2 .blacklight-file .document-title-heading {
+      border-left: 0;
+      padding-left: 0;
+
+      &:before {
+        color: $gray-light;
+        content: "\a6";
+        padding-right: 6px;
+      }
+    }
+
+    .al-hierarchy-level-3 .document-title-heading,
+    .al-hierarchy-level-3 .blacklight-file .document-title-heading {
+      &:before {
+        content: "\205D";
+      }
+    }
   }
 }
 
@@ -12,22 +88,9 @@
   background: $state-warning-bg;
 }
 
-// Collapse arrow indicators
-.al-toggle-view-more {
-  &[aria-expanded="true"] {
-    &::after {
-      content: '\25BC';
-    }
-  }
-
-  &::after {
-    content: '\25B6';
-  }
-}
-
 // Placeholder styling
 .al-hierarchy-placeholder {
-  padding: 5px;
+  margin-top: $spacer;
 
   h3 {
     background-color: $gray-lighter;
@@ -42,7 +105,7 @@
   }
 }
 
-// Class styling for all level hierarchies
+// Indentation styling for all level hierarchies
 @mixin hierarchy-levels {
   @for $i from 1 through 12 {
     .al-hierarchy-level-#{$i} {

--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -4,6 +4,22 @@
   margin-bottom: $spacer;
 }
 
+// Collapse arrow indicators
+.al-toggle-view-more,
+.al-toggle-view-all {
+  &[aria-expanded="true"] {
+    &::after {
+      content: '\25BC';
+      margin-left: 6px;
+    }
+  }
+
+  &::after {
+    content: '\25B6';
+    margin-left: 6px;
+  }
+}
+
 .al-document-title-bar {
   .toggle-bookmark {
     @media (min-width: 576px) and (max-width: 991px) {

--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -39,6 +39,9 @@
 
 .documents-hierarchy {
   .al-number-of-children-badge {
-    margin-left: $spacer * 2;
+    background-color: #eee;
+    border: 1px solid #ccc;
+    color: $gray-light;
+    vertical-align: top;
   }
 }

--- a/app/views/catalog/_collection_contents.html.erb
+++ b/app/views/catalog/_collection_contents.html.erb
@@ -1,5 +1,6 @@
 <% document ||= @document %>
 
+<h2 class="sr-only">Collection inventory</h2>
 <%= content_tag(
   :div, '',
   class: 'al-contents',

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -1,10 +1,23 @@
 <header class="documentHeader row">
-  <h3 class="index_title document-title-heading col-md-12">
+  <h3 class="index_title document-title-heading <%= document.number_of_children > 0 ? 'col-md-9' : 'col-md-12' %> ">
     <% counter = document_counter_with_offset(document_counter) %>
     <%= link_to_document document, document_show_link_field(document), counter: counter %>
-
-    <span class='badge badge-default al-number-of-children-badge'>
-      <%= t(:'arclight.views.index.number_of_children', count: document.number_of_children) %>
-    </span>
   </h3>
+
+  <div class="al-hierarchy-children-status <%= document.number_of_children > 0 ? 'col-md-3' : 'col' %> ">
+    <% if document.number_of_children > 0 %>
+      <span class='badge badge-default al-number-of-children-badge'>
+        <%= t(:'arclight.views.index.number_of_children', count: document.number_of_children) %>
+        <%= link_to(
+          t('arclight.hierarchy.view_all'),
+          "##{document.reference}-collapsible-hierarchy",
+          class: 'al-toggle-view-all',
+            data: {
+              toggle: 'collapse'
+            }
+          )
+        %>
+      </span>
+    <% end %>
+  </div>
 </header>

--- a/app/views/catalog/_index_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_hierarchy_default.html.erb
@@ -3,19 +3,6 @@
 <% end if document.abstract_or_scope %>
 
 <% if document.number_of_children > 0 %>
-
-  <%= link_to(
-        t('arclight.hierarchy.view_more'),
-        "##{document.reference}-collapsible-hierarchy",
-        class: 'al-toggle-view-more',
-        data: {
-          toggle: 'collapse'
-        }
-      )
-  %>
-
-  <hr>
-
   <%= content_tag(:div, id: "#{document.reference}-collapsible-hierarchy",
     class: "collapse al-hierarchy-level-#{document.component_level}",
   ) do %>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -7,7 +7,7 @@ en:
       sidebar_section:
         link: 'Open viewer'
     hierarchy:
-      view_more: 'View more'
+      view_all: 'View'
     request:
       container: 'Request container(s)'
     routes:

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -233,13 +233,13 @@ RSpec.describe 'Collection Page', type: :feature do
       it 'sub components are viewable and expandable' do
         within '#contents' do
           within '.document-position-0' do
-            click_link 'View more'
+            click_link 'View'
             expect(page).to have_css 'a', text: 'Reports'
             within '.blacklight-subseries.document-position-21' do
-              click_link 'View more'
+              click_link 'View'
               expect(page).to have_css 'a', text: 'Expansion Plan'
               within '.blacklight-subseries.document-position-0' do
-                click_link 'View more'
+                click_link 'View'
                 expect(page).to have_css 'a', text: 'Initial Phase'
                 expect(page).to have_css 'a', text: 'Phase II: Expansion'
               end
@@ -249,7 +249,7 @@ RSpec.describe 'Collection Page', type: :feature do
       end
       it 'includes the number of direct children of the component' do
         within '.document-position-0' do
-          expect(page).to have_css('.document-title-heading .al-number-of-children-badge', text: '25 children')
+          expect(page).to have_css('.al-hierarchy-children-status .al-number-of-children-badge', text: '25 children')
         end
       end
 


### PR DESCRIPTION
This is a just a first-pass at making the contents hierarchy a bit more presentable. There are further styling and layout adjustments to make and other problems to solve (more polished iconography, more visible links to component detail pages) but this seems like a worthwhile step forward.

![milton_friedman_papers__1931-2006_-_blacklight](https://cloud.githubusercontent.com/assets/101482/26327397/285539aa-3ef4-11e7-99b9-0c37c100b5eb.png)


Note that these changes have an untended effect on the component detail, Collection Context section in that the children badge in that context should not show the "View" toggle part of the badge, as shown below. If we merge this PR we can address that separately. I also will do styling of the component detail page in case other unintended styling issues have propagated to that page.

![series_ii__membership__1902-1973_-_blacklight](https://cloud.githubusercontent.com/assets/101482/26327409/3564cc00-3ef4-11e7-9099-503bea7df45b.png)
