### PR TITLE
Move bookmark styling to more global context

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -11,3 +11,7 @@
     }
   }
 }
+
+.bookmark-toggle .toggle-bookmark {
+  margin-bottom: 0;
+}

--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -6,10 +6,6 @@
     font-size: $font-size-sm;
     margin: 0 (-$result-item-body-padding - 1px) 0.5rem;
     padding: 3px $result-item-body-padding;
-
-    .toggle-bookmark {
-      margin-bottom: 0;
-    }
   }
 
   // Result item body


### PR DESCRIPTION
Very minor update to put the bookmark checkbox styling in a more global context so we never get the unwanted margin below the label.

### Current
![biographical_file__1931-1980_-_blacklight](https://cloud.githubusercontent.com/assets/101482/26330130/654a3c24-3eff-11e7-9c50-eb1a8e089a5c.png)

### Updated
![biographical_file__1931-1980_-_blacklight 2](https://cloud.githubusercontent.com/assets/101482/26330137/6a9d3fe6-3eff-11e7-8ea6-8cc6964a2971.png)
