### PR TITLE
Update styling of collection sidebar

### DIFF
--- a/app/assets/stylesheets/arclight/modules/show_collection.scss
+++ b/app/assets/stylesheets/arclight/modules/show_collection.scss
@@ -23,6 +23,7 @@
   }
 
   dd {
+    line-height: 1.4;
     margin-bottom: $spacer;
   }
 

--- a/app/assets/stylesheets/arclight/modules/sidebar.scss
+++ b/app/assets/stylesheets/arclight/modules/sidebar.scss
@@ -4,6 +4,10 @@
 
 .al-digital-object {
   margin-bottom: $spacer;
+
+  .al-digital-object-label {
+    margin-bottom: ($spacer / 2);
+  }
 }
 
 // Hiding this from display since we don't need it.

--- a/app/views/arclight/digital_objects/_sidebar_section.html.erb
+++ b/app/views/arclight/digital_objects/_sidebar_section.html.erb
@@ -1,6 +1,6 @@
 <% digital_objects.each do |object| %>
   <div class='al-digital-object'>
-    <div class='al-digtal-object-label'><%= object.label %></div>
-    <%= link_to(t(:'.link'), object.href, class: 'btn btn-primary', role: 'button') %>
+    <div class='al-digital-object-label'><%= object.label %></div>
+    <%= link_to(t(:'.link'), object.href, class: 'btn btn-sm btn-primary', role: 'button') %>
   </div>
 <% end %>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe 'Collection Page', type: :feature do
           # Blacklight renders the dt and it is not necessary in our display
           expect(page).to have_css('dt', visible: false)
 
-          expect(page).to have_css('.al-digtal-object-label', text: 'History slideshow')
+          expect(page).to have_css('.al-digital-object-label', text: 'History slideshow')
           expect(page).to have_css('.btn-primary', text: 'Open viewer')
         end
       end

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe 'Component Page', type: :feature do
 
         expect(page).to have_css('.al-digital-object', count: 2)
 
-        expect(page).to have_css('.al-digtal-object-label', text: 'Folder of digitized stuff')
-        expect(page).to have_css('.al-digtal-object-label', text: /^Letter from Christian B\. Anfinsen/)
+        expect(page).to have_css('.al-digital-object-label', text: 'Folder of digitized stuff')
+        expect(page).to have_css('.al-digital-object-label', text: /^Letter from Christian B\. Anfinsen/)
         expect(page).to have_css('.btn-primary', text: 'Open viewer', count: 2)
       end
     end


### PR DESCRIPTION
A couple of minor styling adjustments to the sidebar:

* Reduce line-height slightly so long text is more compact
* Add spacing before Viewer button
* Fix typo in class name

![alpha_omega_alpha_archives__1894-1992_-_blacklight 2](https://cloud.githubusercontent.com/assets/101482/26331980/d106133a-3f08-11e7-9f26-791476fea60e.png)

---
![alpha_omega_alpha_archives__1894-1992_-_blacklight](https://cloud.githubusercontent.com/assets/101482/26331983/d4bc6358-3f08-11e7-8277-e19fa3875484.png)
