### PR TITLE
Ensure that a title field is present before calling #first on it for …

### DIFF
--- a/lib/arclight/shared_indexing_behavior.rb
+++ b/lib/arclight/shared_indexing_behavior.rb
@@ -78,7 +78,7 @@ module Arclight
 
     def add_normalized_title(solr_doc)
       dates = Arclight::NormalizedDate.new(unitdate_inclusive.first, unitdate_bulk.first, unitdate_other.first).to_s
-      title = Arclight::NormalizedTitle.new(solr_doc['title_ssm'].first, dates, solr_doc['id'].to_s).to_s
+      title = Arclight::NormalizedTitle.new(solr_doc['title_ssm'].try(:first), dates, solr_doc['id'].to_s).to_s
       solr_doc['normalized_title_ssm'] = [title]
       solr_doc['normalized_date_ssm'] = [dates]
       title


### PR DESCRIPTION
…normalized unittitles.

Fixes #361 

@anarchivist there isn't a good way for us to test this w/o a component in our fixtures w/o a title.  Is there one in particular that we could remove, or just leave it as is?