### PR TITLE
Add a .navbar-search div around the search form on the home page.

### DIFF
--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -9,6 +9,7 @@
 
   .search-query-form {
     margin-bottom: $spacer;
+    max-width: 100%;
   }
 
   .navbar {

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -21,7 +21,9 @@
     </div>
     <div class='row'>
       <div class='col-md-6 offset-md-3'>
-        <%= render_search_bar %>
+        <div class='navbar-search'>
+          <%= render_search_bar %>
+        </div>
       </div>
     </div>
     <nav class="navbar" role="navigation">


### PR DESCRIPTION
Also add custom styling to ensure that the search bar takes up the available space.

Fixed #359 

## Before
<img width="1119" alt="before" src="https://cloud.githubusercontent.com/assets/96776/26334465/19932d7a-3f1a-11e7-88f8-f1365ee5979d.png">

## After
<img width="1134" alt="after" src="https://cloud.githubusercontent.com/assets/96776/26334466/19aa6832-3f1a-11e7-91de-71b735ed7ec0.png">