### PR TITLE
Add some whitespace around search result elements

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -41,3 +41,16 @@
     vertical-align: top;
   }
 }
+
+.al-data-range-histogram {
+  margin-bottom: $spacer;
+}
+
+#appliedParams {
+  margin-bottom: ($spacer * 2) !important;
+}
+
+.applied-filter,
+.catalog_startOverLink {
+  margin-bottom: ($spacer / 2);
+}


### PR DESCRIPTION
Minor update to prevent all the search result elements (date histogram, search constraints) from being so tightly packed together.

### Before
![before](https://cloud.githubusercontent.com/assets/101482/26364194/5b5aa8f4-3f98-11e7-9d0f-5b4e40dd8da1.png)

### After
![collection__alpha_omega_alpha_archives__1894-1992___level__other___repository__national_library_of_medicine__history_of_medicine_division_-_blacklight_search_results](https://cloud.githubusercontent.com/assets/101482/26364202/5fe1aea4-3f98-11e7-93f8-cf1931ac1ab2.png)
