### PR TITLE
add containers to Contents tab listing

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy.scss
@@ -3,6 +3,12 @@
     font-size: $font-size-h5;
   }
 
+  .document-title-containers {
+    &:after {
+      padding-right: 3px;
+    }
+  }
+
   // Number of children badge & toggle
   .al-hierarchy-children-status {
     text-align: right;

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -89,7 +89,8 @@ module Arclight
     end
 
     def containers
-      fetch('containers_ssim', [])
+      # note that .titlecase strips punctuation, like hyphens, we want to keep
+      fetch('containers_ssim', []).map(&:capitalize)
     end
 
     def normalized_title

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -1,5 +1,10 @@
 <header class="documentHeader row">
   <h3 class="index_title document-title-heading <%= document.number_of_children > 0 ? 'col-md-9' : 'col-md-12' %> ">
+    <% if document.containers.present? %>
+      <span class="document-title-containers">
+        <%= document.containers.join(', ') %>:
+      </span>
+    <% end %>
     <% counter = document_counter_with_offset(document_counter) %>
     <%= link_to_document document, document_show_link_field(document), counter: counter %>
   </h3>

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -199,7 +199,13 @@ class CatalogController < ApplicationController
     ]
 
     # Component Show Page - Metadata Section
-    config.add_component_field 'containers_ssim', label: 'Containers'
+    config.add_component_field 'containers', label: 'Containers', accessor: 'containers', separator_options: {
+      words_connector: ', ',
+      two_words_connector: ', ',
+      last_word_connector: ', '
+    }, if: lambda { |_context, _field_config, document|
+      document.containers.present?
+    }
     config.add_component_field 'abstract_ssm', label: 'Abstract'
     config.add_component_field 'extent_ssm', label: 'Extent'
     config.add_component_field 'scopecontent_ssm', label: 'Scope and Content'

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -101,6 +101,7 @@
          accessrestrict_ssm,
          child_component_count_isim,
          collection_ssm,
+         containers_ssim,
          creator_ssm,
          extent_ssm,
          geogname_ssm,

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe 'Collection Page', type: :feature do
     end
   end
 
-  describe 'online content idicator' do
-    context 'when there is online content avilable' do
+  describe 'online content indicator' do
+    context 'when there is online content available' do
       it 'is rendered' do
         expect(page).to have_css('.badge-success', text: 'online content')
       end
@@ -234,6 +234,9 @@ RSpec.describe 'Collection Page', type: :feature do
         within '#contents' do
           within '.document-position-0' do
             click_link 'View'
+            within '.blacklight-otherlevel.document-position-3' do
+              expect(page).to have_css '.document-title-containers', text: /Box 1, Folder 4\-5/
+            end
             expect(page).to have_css 'a', text: 'Reports'
             within '.blacklight-subseries.document-position-21' do
               click_link 'View'

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe 'Component Page', type: :feature do
     end
   end
 
+  describe 'metadata' do
+    let(:doc_id) { 'aoa271aspace_dc2aaf83625280ae2e193beb3f4aea78' }
+
+    it 'uses our rules for displaying containers' do
+      expect(page).to have_css('dd', text: 'Box 1, Folder 4-5')
+    end
+  end
+
   describe 'sidebar' do
     it 'includes an online section when the component includes a DAO' do
       within('.al-sticky-sidebar') do

--- a/spec/features/google_form_request_spec.rb
+++ b/spec/features/google_form_request_spec.rb
@@ -18,7 +18,7 @@ describe 'Google Form Request', type: :feature, js: true do
                                    visible: false)
           expect(page).to have_css 'input[name="entry.14428541"][value="Alpha Omega Alpha"]', visible: false
           expect(page).to have_css 'input[name="entry.996397105"][value="aoa271"]', visible: false
-          expect(page).to have_css 'input[name="entry.1125277048"][value="box 1 folder 1"]', visible: false
+          expect(page).to have_css 'input[name="entry.1125277048"][value="Box 1 Folder 1"]', visible: false
           expect(page).to have_css 'input[name="entry.862815208"][value$="William W. Root, n.d."]', visible: false
           expect(page).to have_css 'button[type="submit"]', text: 'Request container(s)'
         end

--- a/spec/models/concerns/arclight/solr_document_spec.rb
+++ b/spec/models/concerns/arclight/solr_document_spec.rb
@@ -93,4 +93,12 @@ RSpec.describe Arclight::SolrDocument do
       expect(document.normalized_date).to eq '1990-2000'
     end
   end
+
+  describe '#containers' do
+    let(:document) { SolrDocument.new(containers_ssim: ['box 1', 'folder 4-5']) }
+
+    it 'uses our rules for joining' do
+      expect(document.containers.join(', ')).to eq 'Box 1, Folder 4-5'
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #339. It adds the container information about a component to the Contents view on the Collection page. It also normalizes the container display as shown on the component view page.  See screenshots below for the before/after behavior.

Note that the CatalogController change was the only way I could get it to work for the various cases we have for containers. It seems long-winded to me so there might be a better way to do that.

## Before on the Collection Contents Page

![screen shot 2017-05-23 at 2 29 07 pm](https://cloud.githubusercontent.com/assets/1861171/26377332/b430856c-3fc4-11e7-9095-a4717b170403.png)

## After on the Collection Contents Page

![screen shot 2017-05-23 at 2 27 50 pm](https://cloud.githubusercontent.com/assets/1861171/26377342/bf96cace-3fc4-11e7-9433-7d46f29030c0.png)


## Before on the Component Detail Page

![screen shot 2017-05-23 at 2 28 49 pm](https://cloud.githubusercontent.com/assets/1861171/26377322/a71a7e3c-3fc4-11e7-9d36-3dc9b3f7137b.png)

## After on the Component Detail Page

![screen shot 2017-05-23 at 2 28 06 pm](https://cloud.githubusercontent.com/assets/1861171/26377315/9d38c766-3fc4-11e7-8b61-0b18c29b36a4.png)
 