### PR TITLE
issue #375 coll index terms fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,10 @@ Metrics/BlockLength:
     - 'tasks/**/*'
     - 'lib/arclight/custom_document.rb'
 
+Metrics/MethodLength:
+  Exclude:
+    - 'lib/arclight/custom_document.rb' # arclight_field_definitions too long
+
 Performance/RegexpMatch:
   Enabled: false
 

--- a/lib/arclight/custom_document.rb
+++ b/lib/arclight/custom_document.rb
@@ -60,20 +60,24 @@ module Arclight
         { name: 'creators', value: creators, index_as: :symbol },
         { name: 'has_online_content', value: online_content?, index_as: :symbol },
         { name: 'repository', value: repository_as_configured(repository), index_as: :displayable },
-        { name: 'repository', value: repository_as_configured(repository), index_as: :facetable }
+        { name: 'repository', value: repository_as_configured(repository), index_as: :facetable },
+        { name: 'names_coll', value: names_coll, index_as: :symbol }
       ]
     end
-    # rubocop: enable Metrics/MethodLength
 
     def names
       [corpname, famname, name, persname].flatten.compact.uniq - repository
+    end
+
+    def names_coll
+      names_array(%w[corpname famname name persname], parent: 'archdesc')
     end
 
     def creators
       [creator_persname, creator_corpname, creator_famname].flatten.compact.uniq - repository
     end
 
-    # Combine subjets into one group from:
+    # Combine subjets into one group from
     #  <controlaccess/><subject></subject>
     #  <controlaccess/><function></function>
     #  <controlaccess/><genreform></genreform>

--- a/lib/arclight/shared_indexing_behavior.rb
+++ b/lib/arclight/shared_indexing_behavior.rb
@@ -20,6 +20,12 @@ module Arclight
       clean_facets_array(subjects.flatten.map(&:text))
     end
 
+    def names_array(elements, parent:)
+      xpath_elements = elements.map { |el| "local-name()='#{el}'" }.join(' or ')
+      names = search("//#{parent}/controlaccess/*[#{xpath_elements}]").to_a
+      clean_facets_array(names.flatten.map(&:text))
+    end
+
     # Return a cleaned array of facets without marc subfields
     #
     # E.g. clean_facets_array(

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -275,11 +275,12 @@ class CatalogController < ApplicationController
       last_word_connector: '<br/>'
     }
 
-    config.add_indexed_terms_field 'names_ssim', label: 'Names', :link_to_facet => true, separator_options: {
+    config.add_indexed_terms_field 'names_coll_ssim', label: 'Names', :link_to_facet => true, separator_options: {
       words_connector: '<br/>',
       two_words_connector: '<br/>',
       last_word_connector: '<br/>'
     }
+
     config.add_indexed_terms_field 'places_ssim', label: 'Places', :link_to_facet => true, separator_options: {
       words_connector: '<br/>',
       two_words_connector: '<br/>',

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -122,7 +122,8 @@
          ref_ssm,
          component_level_isim,
          parent_access_restrict_ssm,
-         parent_access_terms_ssm
+         parent_access_terms_ssm,
+         names_coll_ssim
        </str>
 
        <str name="facet">true</str>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe 'Collection Page', type: :feature do
         expect(page).to have_css('dd', text: 'Root, William Webster, 1867-1932')
         expect(page).to have_css('dd', text: 'Bierring, Walter L. (Walter Lawrence), 1868-1961')
         expect(page).to have_css('dd', text: 'Mindanao Island (Philippines)')
+        expect(page).not_to have_css('dd', text: 'Higgins, L. Raymond')
       end
     end
 


### PR DESCRIPTION
Okay, this PR does not address the separate requirements for facets to index all the elements in each finding aid. It merely changes the display of names in the **indexed terms** section of the collection show page so they are limited to the names under the <archdesc> element.