### PR TITLE
Omit View toggle link in Collection Context view on Component detail page

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -62,6 +62,10 @@ module ArclightHelper
     Arclight::Repository.find_by(name: repos.first.value) if faceted
   end
 
+  def hierarchy_component_context?
+    params[:hierarchy_context] == 'component'
+  end
+
   ##
   # Defines custom helpers used for creating unique metadata blocks to render
   Arclight::Engine.config.catalog_controller_field_accessors.each do |config_field|

--- a/app/views/catalog/_component_overview.html.erb
+++ b/app/views/catalog/_component_overview.html.erb
@@ -25,7 +25,7 @@
     class: 'al-ancestors',
     data: {
       arclight_ancestors: @document.parent_ids,
-      arclight_path: search_catalog_path
+      arclight_path: search_catalog_path(hierarchy_context: 'component')
     }
   ) %>
   <%= content_tag(
@@ -35,7 +35,7 @@
       arclight: {
         hierarchy: true,
         level: @document.component_level,
-        path: search_catalog_path,
+        path: search_catalog_path(hierarchy_context: 'component'),
         name: @document.collection_name,
         parent: @document.parent_ids.last,
         highlight: show_presenter(@document).heading

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -11,7 +11,6 @@
     <%= link_to_document document, document_show_link_field(document), counter: counter %>
   </h3>
 
-  
   <div class="al-hierarchy-side-content float-right <%= side_content ? 'col-md-3' : 'col' %> ">
     <% if requestable %>
       <%= render partial: 'arclight/requests/google_form', locals: { document: document } %>
@@ -20,15 +19,17 @@
       <div class='al-hierarchy-children-status'>
         <span class='badge badge-default al-number-of-children-badge'>
           <%= t(:'arclight.views.index.number_of_children', count: document.number_of_children) %>
-          <%= link_to(
-            t('arclight.hierarchy.view_all'),
-            "##{document.reference}-collapsible-hierarchy",
-            class: 'al-toggle-view-all',
-              data: {
-                toggle: 'collapse'
-              }
-            )
-          %>
+          <% unless hierarchy_component_context? %>
+            <%= link_to(
+              t('arclight.hierarchy.view_all'),
+              "##{document.reference}-collapsible-hierarchy",
+              class: 'al-toggle-view-all',
+                data: {
+                  toggle: 'collapse'
+                }
+              )
+            %>
+          <% end %>
         </span>
       </div>
     <% end %>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -250,9 +250,12 @@ RSpec.describe 'Collection Page', type: :feature do
           end
         end
       end
-      it 'includes the number of direct children of the component' do
+      it 'includes the number of direct children of the component and View link' do
         within '.document-position-0' do
-          expect(page).to have_css('.al-hierarchy-children-status .al-number-of-children-badge', text: '25 children')
+          expect(page).to have_css(
+            '.al-hierarchy-children-status .al-number-of-children-badge',
+            text: /25 children\s+View/
+          )
         end
       end
 

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -82,12 +82,20 @@ RSpec.describe 'Component Page', type: :feature do
         expect(page).to have_css 'h1'
       end
     end
-    it 'has a ancestor list, siblings and highlighted self' do
+    it 'has ancestor component with badge having children count' do
       within '#collection-context' do
-        expect(page).to have_css(
-          '.al-hierarchy-level-0 article a',
-          text: 'Series I: Administrative Records, 1902-1976'
-        )
+        within '.al-hierarchy-level-0' do
+          expect(page).to have_css(
+            'article a',
+            text: 'Series I: Administrative Records, 1902-1976'
+          )
+          expect(page).to have_css('.al-number-of-children-badge', text: '25 children')
+          expect(page).not_to have_css('.al-number-of-children-badge', text: /View/)
+        end
+      end
+    end
+    it 'has siblings and highlighted self' do
+      within '#collection-context' do
         within '.al-contents' do
           expect(page).to have_css(
             '.al-hierarchy-highlight h3',
@@ -95,6 +103,12 @@ RSpec.describe 'Component Page', type: :feature do
           )
           expect(page).to have_css 'article', text: 'Statements of purpose, c.1902'
           expect(page).to have_css 'article', text: 'Constitution - notes on drafting of constitution, c.1902-1903'
+        end
+      end
+    end
+    it 'supports clicks within collection context' do
+      within '#collection-context' do
+        within '.al-contents' do
           click_link('Statements of purpose, c.1902')
         end
       end

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -191,4 +191,14 @@ RSpec.describe ArclightHelper, type: :helper do
       end
     end
   end
+  context '#hierarchy_component_context?' do
+    it 'requires a parameter to enable' do
+      allow(helper).to receive(:params).and_return(hierarchy_context: 'component')
+      expect(helper.hierarchy_component_context?).to be_truthy
+    end
+    it 'omission is disabled' do
+      allow(helper).to receive(:params).and_return({})
+      expect(helper.hierarchy_component_context?).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #374. It removes the "View" link in the # of children badge on the Component detail page within the Collection Context area. Note that I split up some of the collection context tests for clarity.

## On a Collection details page in the Contents tab -- "View" link is there

![screen shot 2017-05-24 at 1 32 58 pm](https://cloud.githubusercontent.com/assets/1861171/26424369/d76eac04-4085-11e7-878f-078d0c22407f.png)


## On a Component details page the View link is omitted

![screen shot 2017-05-24 at 1 33 12 pm](https://cloud.githubusercontent.com/assets/1861171/26424363/d3a418b6-4085-11e7-93a4-5a78089da9f8.png)
