### PR TITLE
add Capybara.default_max_wait_time

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require 'rspec/rails'
 
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
+Capybara.default_max_wait_time = 5 # our ajax responses are sometimes slow
 
 require 'arclight'
 


### PR DESCRIPTION
The collection_page spec (line 233) is failing periodically. It's using capybara to click links, etc. so I'm wondering if Capybara isn't waiting long enough for the ajax response.