### PR TITLE
Update layout and styling of Repository show page

### DIFF
--- a/app/assets/stylesheets/arclight/application.scss
+++ b/app/assets/stylesheets/arclight/application.scss
@@ -5,6 +5,7 @@
 @import 'modules/hierarchy';
 @import 'modules/layout';
 @import 'modules/mastheads';
+@import 'modules/repositories.scss';
 @import 'modules/repository_card.scss';
 @import 'modules/search_results';
 @import 'modules/show_collection';

--- a/app/assets/stylesheets/arclight/modules/repositories.scss
+++ b/app/assets/stylesheets/arclight/modules/repositories.scss
@@ -1,0 +1,29 @@
+.blacklight-repositories-show {
+  .al-repository-show-header {
+    margin-bottom: ($spacer / 2);
+    margin-top: ($spacer * 2);
+
+    h3 {
+      font-size: $font-size-h4;
+    }
+  }
+
+  .al-repository-collections{
+    font-size: $font-size-sm;
+
+    &::after {
+      content: '\bb';
+    }
+  }
+
+  .al-document-title-bar {
+    border-top: $result-item-border-styling;
+    margin-bottom: $spacer;
+    padding-top: ($spacer / 2);
+
+    .al-document-abstract-or-scope,
+    .al-collection-id {
+      font-size: $font-size-sm;
+    }
+  }
+}

--- a/app/views/arclight/repositories/_repository.html.erb
+++ b/app/views/arclight/repositories/_repository.html.erb
@@ -52,7 +52,7 @@
                   <%= t(:'arclight.views.repositories.number_of_collections', count: repository.collection_count) %>
                 </span>
                </div>
-              <button type='button' class='btn btn-secondary btn-sm'>Learn more</button>
+               <%= link_to(t(:'arclight.views.repositories.view_more'), arclight_engine.repository_path(repository.slug), class: 'btn btn-secondary btn-sm') %>
             </div>
           <% end %>
         </div>

--- a/app/views/arclight/repositories/show.html.erb
+++ b/app/views/arclight/repositories/show.html.erb
@@ -1,26 +1,37 @@
 <%= render 'shared/breadcrumbs' %>
 <%= render @repository %>
-<h3>
-  <%= t('arclight.views.show.our_collections') %>
-</h3>
-<br/>
-<% @collections.each do |document| %>
-  <div class="col-md-12">
-    <div class='al-document-title-bar'>
-      <div class='row'>
-        <div class='col-8'>
-          <h5><%= link_to document.normalized_title, solr_document_path(document.id) %></h5>
-          <%= content_tag('div', class: 'al-document-abstract-or-scope', title: document.abstract_or_scope) do %>
-            <%= truncate(document.abstract_or_scope, length: 175) %>
-          <% end if document.abstract_or_scope %>
-        </div>
-        <% if document.unitid %>
-          <div class='col-4 text-right'>
-            <%= t(:'arclight.views.show.collection_id', id: document.unitid) %>
+<div class="row al-repository-show-header">
+  <div class="col col-md-8 col-lg-9">
+    <h3>
+      <%= t('arclight.views.show.our_collections') %>
+    </h3>
+  </div>
+  <div class="col text-right">
+    <span class="al-repository-collections">
+      <%# TODO: This link should go to search results scoped to a) this repository and b) Level = 'collection' #%>
+      <%= link_to(t(:'arclight.views.repositories.view_all_collections'), "#") %>
+    </span>
+  </div>
+</div>
+
+<div class="row">
+  <% @collections.each do |document| %>
+    <div class="col-md-12">
+      <div class='al-document-title-bar'>
+        <div class='row'>
+          <div class='col-md-10 col-lg-9'>
+            <h5><%= link_to document.normalized_title, solr_document_path(document.id) %></h5>
+            <%= content_tag('div', class: 'al-document-abstract-or-scope', title: document.abstract_or_scope) do %>
+              <%= truncate(document.abstract_or_scope, length: 175) %>
+            <% end if document.abstract_or_scope %>
           </div>
-        <% end %>
+          <% if document.unitid %>
+            <div class='col text-right al-collection-id'>
+              <%= t(:'arclight.views.show.collection_id', id: document.unitid) %>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
-  </div>
-  <br/>
-<% end %>
+  <% end %>
+</div>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -54,4 +54,5 @@ en:
           one: '1 collection'
           other: '%{count} collections'
         view_more: 'View more'
+        view_all_collections: 'View all of our collections'
     breadcrumb_separator: ' » '

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -53,4 +53,5 @@ en:
           zero: 'No collections'
           one: '1 collection'
           other: '%{count} collections'
+        view_more: 'View more'
     breadcrumb_separator: ' » '


### PR DESCRIPTION
* Updated the button (now a link styled as a button) on the Repositories index page
* Added a "View all collections" link to the Repository show page (not so useful for us now, but as soon as a repo has more than a handful of collections it will be)
* Updated the layout and styling to look a bit nicer at various viewport sizes

Note that the "View all of our collections" link needs to be updated to actually go somewhere. I don't know the proper route so I just put in a placeholder (with a TODO in the code). The link should go to search results scoped to a) the current repository and b) Level = 'collection'

I can write up a new ticket for that link TODO, or someone could push a commit to this PR. Also, I'm not sure if the two links I added should have tests; if so, probably better for someone else to do that, again either as a new commit to this branch or we can write a new ticket.

### Example Repository show page
![blacklight 2](https://cloud.githubusercontent.com/assets/101482/26429181/626f1384-409a-11e7-8fc6-8959a438b47a.png)
