### PR TITLE
Add a compact view for Blacklight search results.

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -54,3 +54,17 @@
 .catalog_startOverLink {
   margin-bottom: ($spacer / 2);
 }
+
+// Compact Search Results
+.documents-compact {
+  margin-bottom: $spacer;
+
+  .document {
+    border-bottom: $result-item-border-styling;
+    padding: $spacer 0;
+
+    &:first-child {
+      border-top: $result-item-border-styling;
+    }
+  }
+}

--- a/app/views/catalog/_arclight_index_compact_default.html.erb
+++ b/app/views/catalog/_arclight_index_compact_default.html.erb
@@ -1,0 +1,12 @@
+<div class="row">
+  <div class="col-5">
+    <% counter = document_counter_with_offset(document_counter) %>
+    <%= link_to_document document, document_show_link_field(document), counter: counter %>
+  </div>
+  <div class="col-5">
+    <%= render_document_partial(document, :index_breadcrumb) %>
+  </div>
+  <div class="col-2">
+    <%= render_document_partial(document, :arclight_online_content_indicator) %>
+  </div>
+</div>

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -203,7 +203,7 @@ class CatalogController < ApplicationController
       :component_terms_field,
       :cite_field
     ]
-    
+
     # Component Show Page - Metadata Section
     config.add_component_field 'containers', label: 'Containers', accessor: 'containers', separator_options: {
       words_connector: ', ',
@@ -222,7 +222,7 @@ class CatalogController < ApplicationController
       two_words_connector: '<br/>',
       last_word_connector: '<br/>'
     }
-    
+
     # Component Show Page Sidebar - Terms and Condition Section
     config.add_component_terms_field 'parent_access_restrict_ssm', label: 'Restrictions'
     config.add_component_terms_field 'parent_access_terms_ssm', label: 'Terms of Access'
@@ -308,6 +308,11 @@ class CatalogController < ApplicationController
     config.view.hierarchy.display_control = false
     config.view.hierarchy.partials = config.index.partials.dup
     config.view.hierarchy.partials.delete(:index_breadcrumb)
+
+    # #
+    # Compact index view
+    config.view.compact
+    config.view.compact.partials = %i[arclight_index_compact]
 
     ##
     # Extra actions

--- a/spec/features/compact_search_results_spec.rb
+++ b/spec/features/compact_search_results_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Compact Search Results', type: :feature do
+  scenario 'As a user I should be able to view results in a compact display' do
+    visit root_path
+    click_button 'Search'
+
+    expect(page).to have_css('.documents-list')
+    expect(page).to have_css('h3.index_title', text: 'Alpha Omega Alpha Archives, 1894-1992')
+
+    click_link 'Compact'
+
+    expect(page).not_to have_css('.documents-list')
+    expect(page).to have_css('.documents-compact')
+    expect(page).to have_css('article.document', count: 10)
+  end
+end


### PR DESCRIPTION
Closes #247

@ggeisler do you have any thoughts on an SVG icon for this?  Also, we're going w/ the default Blacklight behavior for view type switching (which is not a drop-down), assuming that a downstream application can make that customization if they desire.  Please let us know if we should spend time on customizing the view picker to be a drop-down.

## Example Search Result
![compact-view](https://cloud.githubusercontent.com/assets/96776/26429597/b3caf462-409c-11e7-979f-0e5adcda147a.png)
