### PR TITLE
Update styling of collection context section

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy.scss
@@ -19,6 +19,10 @@
     }
   }
 
+  .al-hierarchy-children-status {
+    text-align: right;
+  }
+
   // Component title + children badge
   .documentHeader {
     border-bottom: $border-width dashed #ccc;
@@ -34,6 +38,7 @@
 
   // Series level
   .blacklight-series .document-title-heading,
+  .blacklight-file .document-title-heading,
   .blacklight-otherlevel .document-title-heading {
     font-size: $font-size-h5;
     font-weight: 400;
@@ -44,7 +49,8 @@
     }
   }
 
-  .blacklight-series {
+  .blacklight-series,
+  .blacklight-file {
     // Additional for levels below series
     .blacklight-subseries .document-title-heading,
     .blacklight-file .document-title-heading,
@@ -106,14 +112,49 @@
   }
 }
 
+// Component show page, Collection context section
+#collection-context {
+  h1 {
+    font-size: $font-size-h5;
+  }
+
+  .documents-hierarchy .documentHeader {
+    margin-top: 1.5rem;
+  }
+
+  // Top-level context
+  .al-hierarchy-level-0 .document-title-heading {
+    // background-color: red;
+    font-size: $font-size-h5;
+    font-weight: 400;
+    margin-bottom: ($spacer / 2);
+
+    > a {
+      color: $gray-dark;
+    }
+  }
+
+  // All subsequent levels
+  @for $i from 1 through 12 {
+    .al-hierarchy-level-#{$i} .document-title-heading {
+      font-size: $font-size-h6;
+      font-weight: 400;
+
+      > a {
+        color: $gray-dark;
+      }
+    }
+  }
+}
+
 // Indentation styling for all level hierarchies
 @mixin hierarchy-levels {
   @for $i from 1 through 12 {
     .al-hierarchy-level-#{$i} {
-      margin-left: 20px;
+      margin-left: 10px;
       // provides for n indention
       &.extra-indent {
-        margin-left: ($i * 20) + px;
+        margin-left: ($i * 10) + px;
       }
     }
   }


### PR DESCRIPTION
Fixes #380.

Styling updates to Collection Context section:

![a-b_-_blacklight](https://cloud.githubusercontent.com/assets/101482/26460697/4f85f342-412f-11e7-9e84-c37f700c228d.png)
