### PR TITLE
add indexing of component subjects

### DIFF
--- a/lib/arclight/custom_component.rb
+++ b/lib/arclight/custom_component.rb
@@ -18,7 +18,8 @@ module Arclight
       t.ref_(path: '/c/@id', index_as: %i[displayable])
 
       # facets
-      t.creator(path: "c/did/origination[@label='creator']/*/text()", index_as: %i[displayable facetable])
+      t.creator(path: "c/did/origination[@label='creator']/*/text()", index_as: %i[displayable facetable symbol])
+      t.places(path: 'c/controlaccess/geogname/text()', index_as: %i[displayable facetable symbol])
 
       add_unitid(t, 'c/')
       add_extent(t, 'c/')
@@ -50,7 +51,7 @@ module Arclight
     def component_field_definitions
       [
         { name: 'level', value: formatted_level, index_as: :facetable },
-        { name: 'access_subjects', value: access_subjects, index_as: :facetable },
+        { name: 'access_subjects', value: access_subjects, index_as: :symbol },
         { name: 'containers', value: containers, index_as: :symbol },
         { name: 'has_online_content', value: online_content?, index_as: :symbol }
       ]

--- a/spec/features/indexing_custom_component_spec.rb
+++ b/spec/features/indexing_custom_component_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
           c.to_solr['ref_ssm'] == ['aspace_01daa89087641f7fc9dbd7a10d3f2da9']
         end.to_solr
 
-        expect(doc1['access_subjects_sim']).to eq ['Minutes']
-        expect(doc2['access_subjects_sim']).to eq ['Records']
+        expect(doc1['access_subjects_ssim']).to eq ['Minutes']
+        expect(doc2['access_subjects_ssim']).to eq ['Records']
       end
     end
 
@@ -48,6 +48,24 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
       it 'has containers for the given component' do
         doc1 = components[1].to_solr
         expect(doc1['containers_ssim']).to eq ['box 1', 'folder 1']
+      end
+    end
+
+    describe '#creator' do
+      it 'has creators for the given component' do
+        doc1 = components.find do |c|
+          c.to_solr['ref_ssm'] == ['aspace_2d7e583e94eb2b46d5dd1a0ec4cdca1f']
+        end.to_solr
+        expect(doc1['creator_ssim'].last).to eq "Higgins, L.\n              Raymond"
+      end
+    end
+
+    describe '#places' do
+      it 'has a place for the given component' do
+        doc1 = components.find do |c|
+          c.to_solr['ref_ssm'] == ['aspace_843e8f9f22bac69872d0802d6fffbb04']
+        end.to_solr
+        expect(doc1['places_ssim']).to eq ['Popes Creek (Md.)']
       end
     end
 
@@ -112,7 +130,6 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
 
       it 'is nil for non normal dates' do
         doc = components[1].to_solr
-
         date_range_field = doc['date_range_sim']
         expect(date_range_field).to be_nil
       end
@@ -163,7 +180,6 @@ RSpec.describe 'Indexing Custom Component', type: :feature do
           expect(doc['has_online_content_ssim']).to eq [true]
         end
       end
-
       context 'when a component does not have online content' do
         it 'is false' do
           doc = components.find do |c|

--- a/spec/features/indexing_custom_document_spec.rb
+++ b/spec/features/indexing_custom_document_spec.rb
@@ -134,6 +134,10 @@ RSpec.describe 'Indexing Custom Document', type: :feature do
       expect(doc['normalized_date_ssm'].first).to eq '1894-1992'
     end
 
+    it '#names_coll' do
+      expect(doc['names_coll_ssim']).to include 'Bierring, Walter L. (Walter Lawrence), 1868-1961'
+    end
+
     describe '#has_online_content' do
       context 'when a document has online content' do
         it 'is true' do

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe 'Search results', type: :feature do
         within('.blacklight-creator_ssim') do
           expect(page).to have_css('h3 a', text: 'Creator')
           expect(page).to have_css('li .facet-label', text: 'Alpha Omega Alpha', visible: false)
+          expect(page).to have_css('li .facet-label', text: 'Stanford University', visible: false)
         end
 
         within('.blacklight-date_range_sim') do
@@ -105,6 +106,7 @@ RSpec.describe 'Search results', type: :feature do
         within('.blacklight-names_ssim') do
           expect(page).to have_css('h3 a', text: 'Names')
           expect(page).to have_css('li .facet-label', text: 'Root, William Webster, 1867-1932', visible: false)
+          expect(page).to have_css('li .facet-label', text: 'Stanford, Leland', visible: false)
         end
 
         within('.blacklight-repository_sim') do
@@ -115,6 +117,7 @@ RSpec.describe 'Search results', type: :feature do
         within('.blacklight-geogname_sim') do
           expect(page).to have_css('h3 a', text: 'Place')
           expect(page).to have_css('li .facet-label', text: 'Mindanao Island (Philippines)', visible: false)
+          expect(page).to have_css('li .facet-label', text: 'Yosemite National Park (Calif.)', visible: false)
         end
 
         within('.blacklight-access_subjects_ssim') do
@@ -123,6 +126,7 @@ RSpec.describe 'Search results', type: :feature do
           expect(page).to have_css('li .facet-label', text: 'Fraternizing', visible: false)
           expect(page).to have_css('li .facet-label', text: 'Photographs', visible: false)
           expect(page).to have_css('li .facet-label', text: 'Medicine', visible: false)
+          expect(page).to have_css('li .facet-label', text: 'Records', visible: false)
         end
 
         within('.blacklight-has_online_content_ssim') do


### PR DESCRIPTION
Makes a small change in lib/arclight/custom_document.rb to get all the terms instead of those under <archdesc> only.