### PR TITLE
turn on highlighting in general search results

### DIFF
--- a/app/assets/stylesheets/arclight/application.scss
+++ b/app/assets/stylesheets/arclight/application.scss
@@ -2,6 +2,7 @@
 @import 'bootstrap_overrides';
 @import 'variables';
 @import 'modules/collection_search';
+@import 'modules/highlights';
 @import 'modules/hierarchy';
 @import 'modules/layout';
 @import 'modules/mastheads';

--- a/app/assets/stylesheets/arclight/modules/highlights.scss
+++ b/app/assets/stylesheets/arclight/modules/highlights.scss
@@ -1,0 +1,10 @@
+.al-document-highlight {
+  padding-top: 10px;
+  padding-left: 10px;
+  font-size: $font-size-xs;
+  font-style: italic;
+  em {
+    background-color: yellow;
+    font-weight: bold;
+  }
+}

--- a/app/models/concerns/arclight/search_behavior.rb
+++ b/app/models/concerns/arclight/search_behavior.rb
@@ -7,7 +7,7 @@ module Arclight
     extend ActiveSupport::Concern
 
     included do
-      self.default_processor_chain += [:add_hierarchy_max_rows]
+      self.default_processor_chain += %i[add_hierarchy_max_rows add_highlighting]
     end
 
     ##
@@ -15,6 +15,17 @@ module Arclight
     def add_hierarchy_max_rows(solr_params)
       if blacklight_params[:view] == 'hierarchy'
         solr_params[:rows] = 999_999_999
+      end
+      solr_params
+    end
+
+    def add_highlighting(solr_params)
+      if blacklight_params[:view] == 'hierarchy'
+        solr_params['hl'] = false
+      else
+        solr_params['hl'] = true
+        solr_params['hl.fl'] = 'text'
+        solr_params['hl.snippets'] = 3
       end
       solr_params
     end

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -118,5 +118,14 @@ module Arclight
     def normalized_date
       first('normalized_date_ssm')
     end
+
+    # @return [Array<String>] with embedded highlights using <em>...</em>
+    def highlights
+      highlight_response = response[:highlighting]
+      return if highlight_response.blank? ||
+                highlight_response[id].blank? ||
+                highlight_response[id][:text].blank?
+      highlight_response[id][:text]
+    end
   end
 end

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -9,3 +9,7 @@
 <%= content_tag('div', class: 'al-document-abstract-or-scope', title: document.abstract_or_scope) do %>
   <%= truncate(document.abstract_or_scope, length: 175) %>
 <% end if document.abstract_or_scope %>
+
+<%= content_tag('div', class: 'al-document-highlight') do %>
+  <%= document.highlights.join('<br/>').html_safe %>
+<% end if document.highlights %>

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -462,7 +462,7 @@
    <field name="_version_" type="long" indexed="true" stored="true" multiValued="false" />
    <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
    <!-- default, catch all search field -->
-   <field name="text" type="text" indexed="true" stored="false" multiValued="true"/>
+   <field name="text" type="text" indexed="true" stored="true" multiValued="true"/>
 
    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
         will be used if the name matches any of the patterns.
@@ -511,6 +511,7 @@
         unknown fields indexed and/or stored by default -->
    <!--dynamicField name="*" type="ignored" multiValued="true" /-->
 
+   <dynamicField name="*_tesim" type="text_en"   stored="true"  indexed="true"  multiValued="true"  />
    <dynamicField name="*_teim"  type="text_en"   stored="false" indexed="true"  multiValued="true"  />
    <dynamicField name="*_si"    type="string"    stored="false" indexed="true"  multiValued="false" />
    <dynamicField name="*_sim"   type="string"    stored="false" indexed="true"  multiValued="true"  />
@@ -542,10 +543,10 @@
    <!-- Copy Fields -->
 
    <!-- field-based searches -->
-   <copyField source="normalized_title_ssm" dest="title_teim"/>
-   <copyField source="places_ssm" dest="place_teim"/>
-   <copyField source="names_ssim" dest="name_teim"/>
-   <copyField source="access_subjects_ssim" dest="subject_teim"/>
+   <copyField source="normalized_title_ssm" dest="title_tesim"/>
+   <copyField source="places_ssm" dest="place_tesim"/>
+   <copyField source="names_ssim" dest="name_tesim"/>
+   <copyField source="access_subjects_ssim" dest="subject_tesim"/>
 
    <!-- The catch all `text` field -->
    <!-- grab the fielded searches -->

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -85,11 +85,11 @@
        -->
 
        <str name="qf">
-         title_teim^100
+         title_tesim^100
          text^10
        </str>
        <str name="pf">
-         title_teim^100
+         title_tesim^100
          text^10
        </str>
 
@@ -142,7 +142,6 @@
        <str name="spellcheck.extendedResults">true</str>
        <str name="spellcheck.collate">false</str>
        <str name="spellcheck.count">5</str>
-
      </lst>
     <arr name="last-components">
       <str>spellcheck</str>
@@ -157,14 +156,14 @@
       <int name="rows">10</int>
       <str name="q.alt">*:*</str>
       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
-      <str name="df">name_teim</str>
+      <str name="df">name_tesim</str>
       <str name="q.op">AND</str>
 
       <str name="qf">
-        name_teim
+        name_tesim
       </str>
       <str name="pf">
-        name_teim
+        name_tesim
       </str>
 
       <str name="fl">*</str>
@@ -187,14 +186,14 @@
       <int name="rows">10</int>
       <str name="q.alt">*:*</str>
       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
-      <str name="df">place_teim</str>
+      <str name="df">place_tesim</str>
       <str name="q.op">AND</str>
 
       <str name="qf">
-        place_teim
+        place_tesim
       </str>
       <str name="pf">
-        place_teim
+        place_tesim
       </str>
 
       <str name="fl">*</str>
@@ -217,14 +216,14 @@
       <int name="rows">10</int>
       <str name="q.alt">*:*</str>
       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
-      <str name="df">subject_teim</str>
+      <str name="df">subject_tesim</str>
       <str name="q.op">AND</str>
 
       <str name="qf">
-        subject_teim
+        subject_tesim
       </str>
       <str name="pf">
-        subject_teim
+        subject_tesim
       </str>
 
       <str name="fl">*</str>
@@ -247,14 +246,14 @@
       <int name="rows">10</int>
       <str name="q.alt">*:*</str>
       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
-      <str name="df">title_teim</str>
+      <str name="df">title_tesim</str>
       <str name="q.op">AND</str>
 
       <str name="qf">
-        title_teim
+        title_tesim
       </str>
       <str name="pf">
-        title_teim
+        title_tesim
       </str>
 
       <str name="fl">*</str>

--- a/spec/features/highlighted_search_results_spec.rb
+++ b/spec/features/highlighted_search_results_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Highlighted search results', type: :feature do
+  describe 'when querying' do
+    context '#all_fields' do
+      it 'highlights the snippets' do
+        visit search_catalog_path q: 'student life', search_field: 'all_fields'
+        within '.document-position-0' do
+          within '.al-document-highlight' do
+            expect(page).to have_css 'em', text: /^student$/, count: 2
+            expect(page).to have_css 'em', text: 'students', count: 1
+            expect(page).to have_css 'em', text: 'life', count: 1
+          end
+        end
+      end
+      it 'does not highlight the snippets on empty query' do
+        visit search_catalog_path q: '', search_field: 'all_fields'
+        within '.document-position-0' do
+          expect(page).not_to have_css '.al-document-highlight'
+        end
+      end
+      it 'does not highlight the snippets on hierarchy query' do
+        visit search_catalog_path q: 'student life', search_field: 'all_fields', view: 'hierarchy'
+        within '.document-position-0' do
+          expect(page).not_to have_css '.al-document-highlight'
+        end
+      end
+    end
+    context '#name' do
+      it 'highlights the snippets' do
+        visit search_catalog_path q: 'william root', search_field: 'name'
+        within '.document-position-0' do
+          within '.al-document-highlight' do
+            expect(page).to have_css 'em', text: 'William', count: 3
+            expect(page).to have_css 'em', text: 'Root', count: 3
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/concerns/arclight/solr_document_spec.rb
+++ b/spec/models/concerns/arclight/solr_document_spec.rb
@@ -125,4 +125,42 @@ RSpec.describe Arclight::SolrDocument do
       expect(document.parent_terms).to eq 'Must use gloves with photos.'
     end
   end
+
+  describe '#highlights' do
+    before { allow(document).to receive(:response).and_return(response) }
+
+    context 'without any highlighting data at all' do
+      let(:response) { { highlighting: {} } }
+
+      it 'handles gracefully' do
+        expect(document.highlights).to be_falsey
+      end
+    end
+
+    context 'without any highlighting hits for document' do
+      let(:response) { { highlighting: { document.id => {} } } }
+
+      it 'handles gracefully' do
+        expect(document.highlights).to be_falsey
+      end
+    end
+
+    context 'with highlighting hits for document but wrong field' do
+      let(:response) { { highlighting: { document.id => { title: %w[my hits] } } } }
+
+      it 'handles gracefully' do
+        expect(document.highlights).to be_falsey
+      end
+    end
+
+    context 'with highlighting hits' do
+      let(:response) { { highlighting: { document.id => { text: %w[my hits] } } } }
+
+      it 'handles gracefully' do
+        expect(document.highlights).to be_truthy
+        expect(document.highlights.length).to eq 2
+        expect(document.highlights.join).to eq 'myhits'
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #245. It changes the Solr configuration to support highlighting in each of the handlers by switching the relevant fields to stored and indexed. The highlights are shown beneath each document and is limited to 3 lines -- note the styling may need to be improved. The feature works for all the fielded searches.

See https://github.com/sul-dlss/arclight/issues/245#issuecomment-304129582 for additional screenshots

![screen shot 2017-05-25 at 3 24 24 pm](https://cloud.githubusercontent.com/assets/1861171/26473084/44c452a8-415e-11e7-9db8-b5fd55845176.png)
