### PR TITLE
#382: Add paragraph separator to notes fields

### DIFF
--- a/app/controllers/concerns/arclight/field_config_helpers.rb
+++ b/app/controllers/concerns/arclight/field_config_helpers.rb
@@ -5,6 +5,8 @@ module Arclight
   # A module to add configuration helpers for certain fields used by Arclight
   module FieldConfigHelpers
     extend ActiveSupport::Concern
+    include ActionView::Helpers::OutputSafetyHelper
+    include ActionView::Helpers::TagHelper
 
     included do
       if respond_to?(:helper_method)
@@ -16,6 +18,7 @@ module Arclight
         helper_method :context_sidebar_visit_note
         helper_method :context_sidebar_containers_request
         helper_method :item_requestable?
+        helper_method :paragraph_separator
       end
     end
 
@@ -71,6 +74,10 @@ module Arclight
           google_form: Arclight::Requests::GoogleForm.new(document, presenter, solr_document_url(document))
         }
       )
+    end
+
+    def paragraph_separator(args)
+      safe_join(args[:value].map { |paragraph| content_tag(:p, paragraph) })
     end
   end
 end

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -250,23 +250,23 @@ class CatalogController < ApplicationController
     config.add_cite_field 'prefercite_ssm', label: 'Preferred citation'
 
     # Collection Show Page - Access Section
-    config.add_access_field 'accessrestrict_ssm', label: 'Conditions Governing Access'
-    config.add_access_field 'userestrict_ssm', label: 'Terms Of Use'
+    config.add_access_field 'accessrestrict_ssm', label: 'Conditions Governing Access', helper_method: :paragraph_separator
+    config.add_access_field 'userestrict_ssm', label: 'Terms Of Use', helper_method: :paragraph_separator
 
     # Collection Show Page - Background Section
-    config.add_background_field 'scopecontent_ssm', label: 'Scope and Content'
-    config.add_background_field 'bioghist_ssm', label: 'Biographical / Historical'
-    config.add_background_field 'acqinfo_ssm', label: 'Acquisition information'
-    config.add_background_field 'appraisal_ssm', label: 'Appraisal information'
-    config.add_background_field 'custodhist_ssm', label: 'Custodial history'
-    config.add_background_field 'processinfo_ssm', label: 'Processing information'
+    config.add_background_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :paragraph_separator
+    config.add_background_field 'bioghist_ssm', label: 'Biographical / Historical', helper_method: :paragraph_separator
+    config.add_background_field 'acqinfo_ssm', label: 'Acquisition information', helper_method: :paragraph_separator
+    config.add_background_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :paragraph_separator
+    config.add_background_field 'custodhist_ssm', label: 'Custodial history', helper_method: :paragraph_separator
+    config.add_background_field 'processinfo_ssm', label: 'Processing information', helper_method: :paragraph_separator
 
     # Collection Show Page - Related Section
-    config.add_related_field 'relatedmaterial_ssm', label: 'Related material'
-    config.add_related_field 'separatedmaterial_ssm', label: 'Separated material'
-    config.add_related_field 'otherfindaid_ssm', label: 'Other finding aids'
-    config.add_related_field 'altformavail_ssm', label: 'Alternative form available'
-    config.add_related_field 'originalsloc_ssm', label: 'Location of originals'
+    config.add_related_field 'relatedmaterial_ssm', label: 'Related material', helper_method: :paragraph_separator
+    config.add_related_field 'separatedmaterial_ssm', label: 'Separated material', helper_method: :paragraph_separator
+    config.add_related_field 'otherfindaid_ssm', label: 'Other finding aids', helper_method: :paragraph_separator
+    config.add_related_field 'altformavail_ssm', label: 'Alternative form available', helper_method: :paragraph_separator
+    config.add_related_field 'originalsloc_ssm', label: 'Location of originals', helper_method: :paragraph_separator
 
     # Collection Show Page - Indexed Terms Section
     config.add_indexed_terms_field 'access_subjects_ssim', label: 'Subjects', :link_to_facet => true, separator_options: {

--- a/spec/controllers/concerns/arclight/field_config_helpers_spec.rb
+++ b/spec/controllers/concerns/arclight/field_config_helpers_spec.rb
@@ -84,4 +84,11 @@ RSpec.describe Arclight::FieldConfigHelpers do
       expect(content).to eq 'Containers are stored offsite and must be pages 2 to 3 days in advance'
     end
   end
+
+  describe '#paragraph_separator' do
+    it 'returns paragraphs' do
+      content = helper.paragraph_separator(value: ['The lazy dog', 'jumped over', 'the sleeping fox.'])
+      expect(content).to eq '<p>The lazy dog</p><p>jumped over</p><p>the sleeping fox.</p>'
+    end
+  end
 end

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe 'Collection Page', type: :feature do
       end
     end
 
+    it 'notes are rendered as paragaphs' do
+      within 'dd.blacklight-bioghist_ssm' do
+        expect(page).to have_css('p', count: 2)
+        expect(page).to have_css('p', text: /^Alpha Omega Alpha Honor Medical Society was founded/)
+        expect(page).to have_css('p', text: /^Root and his fellow medical students/)
+      end
+    end
+
     it 'background has configured metadata' do
       within '#background' do
         expect(page).to have_css('dt', text: 'Scope and Content')


### PR DESCRIPTION
Closes #382 

We implemented the multiline creators field with line breaks instead of paragraph tags (similar to Indexed Terms). `link_to_facet` and `helper_method` don't play well together.

![paragraph_separator](https://cloud.githubusercontent.com/assets/5402927/26473912/eb2cba5a-4162-11e7-81cc-69a0d0701e90.png)

