### PR TITLE
add sorting by title, date, and creator

### DIFF
--- a/app/models/concerns/arclight/search_behavior.rb
+++ b/app/models/concerns/arclight/search_behavior.rb
@@ -7,7 +7,11 @@ module Arclight
     extend ActiveSupport::Concern
 
     included do
-      self.default_processor_chain += %i[add_hierarchy_max_rows add_highlighting]
+      self.default_processor_chain += %i[
+        add_hierarchy_max_rows
+        add_hierarchy_sort
+        add_highlighting
+      ]
     end
 
     ##
@@ -19,6 +23,15 @@ module Arclight
       solr_params
     end
 
+    ##
+    # For the hierarchy view, set the sort order to preserve the order of components
+    def add_hierarchy_sort(solr_params)
+      solr_params[:sort] = 'sort_ii asc' if blacklight_params[:view] == 'hierarchy'
+      solr_params
+    end
+
+    ##
+    # Disable highlighting for hiearchy, and enable it for all other searches
     def add_highlighting(solr_params)
       if blacklight_params[:view] == 'hierarchy'
         solr_params['hl'] = false

--- a/lib/arclight/custom_component.rb
+++ b/lib/arclight/custom_component.rb
@@ -29,6 +29,14 @@ module Arclight
     def to_solr(solr_doc = {})
       super
       solr_doc['id'] = Arclight::NormalizedId.new(solr_doc['id']).to_s
+      solr_doc['creator_sort'] = creator.to_a.join(', ') if creator.present?
+      add_component_fields(solr_doc)
+      solr_doc
+    end
+
+    private
+
+    def add_component_fields(solr_doc)
       component_field_definitions.each do |field|
         # we want to use `set_field` rather than `insert_field` since we may be overriding fields
         Solrizer.set_field(solr_doc, field[:name], field[:value], field[:index_as])
@@ -37,11 +45,7 @@ module Arclight
       add_normalized_title(solr_doc)
       resolve_repository(solr_doc)
       add_digital_content(prefix: 'c/did', solr_doc: solr_doc)
-
-      solr_doc
     end
-
-    private
 
     def component_field_definitions
       [

--- a/lib/arclight/custom_document.rb
+++ b/lib/arclight/custom_document.rb
@@ -31,6 +31,14 @@ module Arclight
     def to_solr(solr_doc = {})
       super
       solr_doc['id'] = Arclight::NormalizedId.new(eadid.first).to_s
+      solr_doc['creator_sort'] = creator.to_a.join(', ') if creator.present?
+      add_document_fields(solr_doc)
+      solr_doc
+    end
+
+    private
+
+    def add_document_fields(solr_doc)
       arclight_field_definitions.each do |field|
         # we want to use `set_field` rather than `insert_field` since we may be overriding fields
         Solrizer.set_field(solr_doc, field[:name], field[:value], field[:index_as])
@@ -39,11 +47,7 @@ module Arclight
       add_date_ranges(solr_doc)
       add_digital_content(prefix: 'ead/archdesc', solr_doc: solr_doc)
       add_normalized_titles(solr_doc)
-
-      solr_doc
     end
-
-    private
 
     def add_normalized_titles(solr_doc)
       title = add_normalized_title(solr_doc)

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -157,7 +157,13 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, title_filing_si asc', label: 'relevance'
+    config.add_sort_field 'score desc, title_sort asc', label: 'relevance'
+    config.add_sort_field 'date_sort asc', label: 'date (ascending)'
+    config.add_sort_field 'date_sort desc', label: 'date (descending)'
+    config.add_sort_field 'creator_sort asc', label: 'creator (A-Z)'
+    config.add_sort_field 'creator_sort desc', label: 'creator (Z-A)'
+    config.add_sort_field 'title_sort asc', label: 'title (A-Z)'
+    config.add_sort_field 'title_sort desc', label: 'title (Z-A)'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -337,7 +337,7 @@
          With various TokenFilterFactories to produce a sortable field
          that does not include some properties of the source text
       -->
-    <fieldType name="alphaOnlySort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+    <fieldType name="alphaNumericSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
       <analyzer>
         <!-- KeywordTokenizer does no actual tokenizing, so the entire
              input string is preserved as a single token
@@ -361,7 +361,7 @@
              http://java.sun.com/j2se/1.5.0/docs/api/java/util/regex/package-summary.html
           -->
         <filter class="solr.PatternReplaceFilterFactory"
-                pattern="([^a-z])" replacement="" replace="all"
+                pattern="([^a-z0-9])" replacement="" replace="all"
         />
       </analyzer>
     </fieldType>
@@ -500,7 +500,7 @@
 
    <dynamicField name="*_display" type="string" indexed="false" stored="true" multiValued="true" />
    <dynamicField name="*_facet" type="string" indexed="true" stored="false" multiValued="true" />
-   <dynamicField name="*_sort" type="alphaOnlySort" indexed="true" stored="false" multiValued="false" />
+   <dynamicField name="*_sort" type="alphaNumericSort" indexed="true" stored="false" multiValued="false" />
    <dynamicField name="*_unstem_search" type="text_general" indexed="true" stored="false" multiValued="true" />
    <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
    <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
@@ -586,8 +586,8 @@
    <!-- <copyField source="title_t" dest="title_unstem_search"/> -->
 
    <!-- sort fields -->
-   <!-- <copyField source="pub_date" dest="pub_date_sort"/> -->
-
+   <copyField source="normalized_title_ssm" dest="title_sort"/> <!-- TODO: assumes single values -->
+   <copyField source="normalized_date_ssm" dest="date_sort"/> <!-- TODO: assumes single values -->
 
    <!-- spellcheck fields -->
    <!-- default spell check;  should match fields for default request handler -->

--- a/spec/features/google_form_request_spec.rb
+++ b/spec/features/google_form_request_spec.rb
@@ -39,8 +39,8 @@ describe 'Google Form Request', type: :feature, js: true do
   end
   context 'in search results' do
     it 'shows up when item is requestable' do
-      visit search_catalog_path q: '', search_field: 'all_fields'
-      expect(page).to have_css 'form[action*="https://docs.google.com"]', count: 7
+      visit search_catalog_path q: 'alpha', search_field: 'all_fields'
+      expect(page).to have_css 'form[action*="https://docs.google.com"]', count: 4
     end
   end
   context 'in collection hierarchy' do

--- a/spec/features/item_breadcrumbs_spec.rb
+++ b/spec/features/item_breadcrumbs_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe 'Item breadcrumb', type: :feature do
   it 'results page shows navigable breadcrumbs' do
-    visit search_catalog_path q: '', search_field: 'all_fields', per_page: 40
+    visit search_catalog_path q: 'expansion', search_field: 'all_fields'
     document = page.all('article').find do |doc|
       doc.all('h3 a', text: 'Phase II: Expansion').present?
     end

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Search results', type: :feature do
     it 'renders the expected metadata for a collection' do
       visit search_catalog_path q: '', search_field: 'all_fields'
 
-      within('.document.document-position-0') do
+      within('.document.document-position-1') do
         within('.al-document-title-bar') do
           expect(page).to have_content 'National Library of Medicine. History of Medicine Division: MS C 271'
         end
@@ -162,6 +162,14 @@ RSpec.describe 'Search results', type: :feature do
       page.find('[href="#al-date-range-histogram-content"]').click
       within '.distribution.subsection.chart_js' do
         expect(page).to have_css 'canvas', visible: false
+      end
+    end
+  end
+  describe 'sorting' do
+    it 'provides a dropdown with all the options' do
+      visit search_catalog_path q: '', search_field: 'all_fields'
+      within '.sort-dropdown' do
+        expect(page).to have_css '.dropdown-item', count: 7
       end
     end
   end

--- a/spec/models/concerns/arclight/search_behavior_spec.rb
+++ b/spec/models/concerns/arclight/search_behavior_spec.rb
@@ -44,4 +44,18 @@ describe Arclight::SearchBehavior do
       end
     end
   end
+  describe '#add_highlighting' do
+    context 'when in hierarchy view' do
+      let(:user_params) { { view: 'hierarchy' } }
+
+      it 'disables highlighting' do
+        expect(search_builder_instance.add_highlighting(solr_params)).to include('hl' => false)
+      end
+    end
+    context 'when not in hierarchy view' do
+      it 'enables highlighting' do
+        expect(search_builder_instance.add_highlighting(solr_params)).to include('hl' => true)
+      end
+    end
+  end
 end

--- a/spec/models/concerns/arclight/search_behavior_spec.rb
+++ b/spec/models/concerns/arclight/search_behavior_spec.rb
@@ -30,4 +30,18 @@ describe Arclight::SearchBehavior do
       end
     end
   end
+  describe '#add_hierarchy_sort' do
+    context 'when in hierarchy view' do
+      let(:user_params) { { view: 'hierarchy' } }
+
+      it 'adds component-order sort to query' do
+        expect(search_builder_instance.add_hierarchy_sort(solr_params)).to include(sort: 'sort_ii asc')
+      end
+    end
+    context 'when not in hierarchy view' do
+      it 'does not affect sort param' do
+        expect(search_builder_instance.add_hierarchy_sort(solr_params)).to eq({})
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #367. It creates new `title_sort`, `creator_sort`, and `date_sort` fields. It also changes the hiearchy sort parameter to `sort_ii asc` which preserves the order of components in the EAD.

Note that the default sorting before this PR was wonky (it was only using `title_filing_si` which is the `titleproper` field and not present for components 😞 ). Therefore, this PR changes some of the failing tests to match the result order with the correct ordering by `title_sort`.

Note that creator is multi-valued so `copyField` doesn't work for it (title and date are also multivalued but in practice they're single-valued -- marked this with a TODO). Also adds a missing test for the highlighting search builder behavior.

![screen shot 2017-05-25 at 4 15 16 pm](https://cloud.githubusercontent.com/assets/1861171/26474643/1269104c-4167-11e7-86a5-668e50ded58a.png)
