### PR TITLE
A few updates to the repositories pages

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -11,6 +11,15 @@ module ArclightHelper
     end, t('arclight.breadcrumb_separator'))
   end
 
+  def repository_collections_path(repository)
+    search_action_url(
+      f: {
+        repository_sim: [repository.name],
+        level_sim: ['Collection']
+      }
+    )
+  end
+
   ##
   # Classes used for customized show page in arclight
   def custom_show_content_classes

--- a/app/views/arclight/repositories/_repository.html.erb
+++ b/app/views/arclight/repositories/_repository.html.erb
@@ -7,7 +7,7 @@
 
       <div class="col-sm-12 col-lg-10 al-repository-information">
         <h2>
-          <%= link_to(repository.name, arclight_engine.repository_path(repository.slug)) %>
+          <%= link_to_unless(params[:id] == repository.slug, repository.name, arclight_engine.repository_path(repository.slug)) %>
         </h2>
         <div class='row no-gutters justify-content-md-center'>
           <div class='col-4 col-md-3 al-repository-contact'>

--- a/app/views/arclight/repositories/index.html.erb
+++ b/app/views/arclight/repositories/index.html.erb
@@ -1,6 +1,4 @@
 <div class="al-repositories">
   <%= render 'shared/breadcrumbs' %>
-  <% @repositories.each do |repository| %>
-    <%= render repository %>
-  <% end %>
+  <%= render @repositories %>
 </div>

--- a/app/views/arclight/repositories/show.html.erb
+++ b/app/views/arclight/repositories/show.html.erb
@@ -8,8 +8,7 @@
   </div>
   <div class="col text-right">
     <span class="al-repository-collections">
-      <%# TODO: This link should go to search results scoped to a) this repository and b) Level = 'collection' #%>
-      <%= link_to(t(:'arclight.views.repositories.view_all_collections'), "#") %>
+      <%= link_to(t(:'arclight.views.repositories.view_all_collections'), repository_collections_path(@repository)) %>
     </span>
   </div>
 </div>

--- a/spec/features/repositories_page_spec.rb
+++ b/spec/features/repositories_page_spec.rb
@@ -33,5 +33,18 @@ RSpec.describe 'Repositores Page', type: :feature do
 
       expect(page).to have_css('.al-collection-count', text: '2 collections')
     end
+
+    it 'does not link the same page in the repository card header' do
+      visit '/repositories'
+
+      click_link 'Stanford University Libraries. Special Collections and University Archives'
+
+      within '.al-repository' do
+        expect(page).not_to have_css(
+          'h2 a',
+          text: 'Stanford University Libraries. Special Collections and University Archives'
+        )
+      end
+    end
   end
 end

--- a/spec/features/repositories_page_spec.rb
+++ b/spec/features/repositories_page_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Repositores Page', type: :feature do
+  it 'is navigabe from the home page' do
+    visit '/'
+
+    within '.al-homepage-masthead' do
+      click_link 'Repositories'
+    end
+
+    within '.al-repositories' do
+      expect(page).to have_css('.al-repository h2 a', text: 'My Repository')
+    end
+  end
+
+  describe 'Repostory Show Page' do
+    it 'is navigable form the Repositories page' do
+      visit '/repositories'
+
+      click_link 'Stanford University Libraries. Special Collections and University Archives'
+
+      expect(page).to have_css('h3', text: 'Our Collections')
+    end
+
+    it 'links to all the repositories collections' do
+      visit '/repositories'
+
+      click_link 'Stanford University Libraries. Special Collections and University Archives'
+
+      click_link 'View all of our collections'
+
+      expect(page).to have_css('.al-collection-count', text: '2 collections')
+    end
+  end
+end

--- a/spec/views/repositories/show.html.erb_spec.rb
+++ b/spec/views/repositories/show.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'arclight/repositories/show', type: :view do
     assign(:repository, test_data)
     assign(:collections, [])
     allow(view).to receive(:on_repositories_show?).and_return(true)
+    allow(view).to receive(:search_action_url).and_return('/')
   end
 
   context 'renders a repository detail page' do


### PR DESCRIPTION
Closes #394 

* Removes the link to the repository show page when the repository card is being rendered at the top of the repository show page.
* Links the "View all our collections" link on the repository show page (scoped to collections w/i that repository).


## Non linked repository title
<img width="1213" alt="repository-page" src="https://cloud.githubusercontent.com/assets/96776/26513297/9b0908b8-421f-11e7-9072-908471d92a43.png">


## View all our collections link
![repository-collections](https://cloud.githubusercontent.com/assets/96776/26513294/96f4d360-421f-11e7-8b4b-e9b21253d623.gif)

