### PR TITLE
[PROPOSAL] Add an Update generator that does the install steps in a non-forceful way

### DIFF
--- a/lib/generators/arclight/update_generator.rb
+++ b/lib/generators/arclight/update_generator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'generators/arclight/install_generator'
+
+module Arclight
+  ##
+  # Arclight Update generator. This subclasses the Install generator, so this is
+  # intended to override behavior in the install generator that can allow the
+  # downstream application to choose if they want to take our changes or not and
+  # can choose to see a diff of our changes to help them decide.
+  class Update < Arclight::Install
+    source_root File.expand_path('../templates', __FILE__)
+
+    def create_blacklight_catalog
+      copy_file 'catalog_controller.rb', 'app/controllers/catalog_controller.rb'
+    end
+
+    def solr_config
+      directory '../../../../solr', 'solr'
+    end
+  end
+end


### PR DESCRIPTION
Wondering if this could be useful in thinking about #381.

For our demo app we simply run `rails g arclight:install` to update it each time (since we don't customize anything really).  The things that we generate during our installation, that commonly need to be updated are the solr and catalog controller configurations.  Our installer forcefully updates both of these (for necessary reasons).

This PR introduces an update generator (`rails g arclight:update`) that subclasses the install generator.  This has the benefit of easily allowing downstream applications to get additional generated code (e.g. added initializers, insertions into downstream classes, etc) while allowing us to override certain parts of the install process to be non-forceful.

In the gif below you can see that my local changes to the catalog controller are preserved as I was given the option to overwrite my changes (I choose to view a diff so I can see what the upstream changes are before deciding not to accept them).

![al-update](https://cloud.githubusercontent.com/assets/96776/26514362/37916c10-4226-11e7-81b3-a3dcd45e2c3a.gif)
