### PR TITLE
Fix uneven buttons

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -46,14 +46,10 @@
   margin-bottom: $spacer;
 }
 
-#appliedParams {
-  margin-bottom: ($spacer * 2) !important;
+.blacklight-catalog-index #appliedParams {
+  margin-bottom: ($spacer * 3) !important;
 }
 
-.applied-filter,
-.catalog_startOverLink {
-  margin-bottom: ($spacer / 2);
-}
 
 // Compact Search Results
 .documents-compact {


### PR DESCRIPTION
Fixes #410.

Buttons are now even:

![alpha_omega_alpha_archives__1894-1992_-_blacklight](https://cloud.githubusercontent.com/assets/101482/26515165/e73cfa3e-422c-11e7-980c-c243438864a1.png)
