### PR TITLE
Add section headings to truncated component metadata

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy.scss
@@ -36,6 +36,13 @@
     line-height: 1.25;
   }
 
+  .al-document-abstract-or-scope-heading {
+    color: #636c72;
+    font-size: $font-size-xs;
+    font-weight: normal;
+    text-transform: uppercase;
+  }
+
   // Series level
   .blacklight-series .document-title-heading,
   .blacklight-file .document-title-heading,

--- a/app/assets/stylesheets/arclight/modules/hierarchy.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy.scss
@@ -36,8 +36,8 @@
     line-height: 1.25;
   }
 
-  .al-document-abstract-or-scope-heading {
-    color: #636c72;
+  .al-hierarchy-sub-heading {
+    color: $gray-light;
     font-size: $font-size-xs;
     font-weight: normal;
     text-transform: uppercase;

--- a/app/views/catalog/_index_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_hierarchy_default.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag('div', class: 'al-document-abstract-or-scope', title: document.abstract_or_scope) do %>
+  <%= content_tag(:h4,'Scope and Contents', class: 'al-document-abstract-or-scope-heading') %>
   <%= truncate(document.abstract_or_scope, length: 175) %>
 <% end if document.abstract_or_scope %>
 

--- a/app/views/catalog/_index_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_hierarchy_default.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag('div', class: 'al-document-abstract-or-scope', title: document.abstract_or_scope) do %>
-  <%= content_tag(:h4,'Scope and Contents', class: 'al-document-abstract-or-scope-heading') %>
+  <%= content_tag(:h4,'Scope and Contents', class: 'al-hierarchy-sub-heading') %>
   <%= truncate(document.abstract_or_scope, length: 175) %>
 <% end if document.abstract_or_scope %>
 

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -239,6 +239,16 @@ RSpec.describe 'Collection Page', type: :feature do
         end
         expect(page).to have_css '.show-document', text: /Series I: Administrative Records/
       end
+      it 'displays truncated component metadata' do
+        within '#contents' do
+          within '.document-position-0 ' do
+            expect(page).to have_css(
+              '.al-document-abstract-or-scope',
+              text: /^SCOPE AND CONTENTS Administrative records include.*\.{3}$/i
+            )
+          end
+        end
+      end
       it 'sub components are viewable and expandable' do
         within '#contents' do
           within '.document-position-0' do

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe 'Collection Page', type: :feature do
           within '.document-position-0 ' do
             expect(page).to have_css(
               '.al-document-abstract-or-scope',
-              text: /^SCOPE AND CONTENTS Administrative records include.*\.{3}$/i
+              text: /^SCOPE AND CONTENTS Administrative records include.*\.{3}/i
             )
           end
         end


### PR DESCRIPTION
Closes #379 

This adds "Scope and Contents" to components in the hierarchy view. I added a feature test for the truncated component metadata as well. The test assumes that truncation length can change but the metadata should end in ellipses. 

Feedback would be much appreciated! 

## Screenshot

![scope_and_contents_heading](https://cloud.githubusercontent.com/assets/5402927/26516547/d7334bf6-423c-11e7-9e5b-48a74ce944c8.png)