### PR TITLE
add Download dropdown to Collection show page

### DIFF
--- a/app/views/catalog/_collection_downloads.html.erb
+++ b/app/views/catalog/_collection_downloads.html.erb
@@ -1,0 +1,17 @@
+<% if downloads.present? && (downloads[:pdf].present? || downloads[:ead].present?) %>
+<li>
+  <div class='dropdown'>
+    <button class='btn btn-secondary dropdown-toggle' type="button" id="download-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <%= t 'arclight.views.show.download.default' %>
+    </button>
+    <div class="dropdown-menu" aria-labelledby="download-dropdown">
+      <% if downloads[:pdf].present? %>
+        <a class="dropdown-item" href="<%= downloads[:pdf][:href] %>"><%= t('arclight.views.show.download.pdf', size: downloads[:pdf][:size]) %></a>
+      <% end %>
+      <% if downloads[:ead].present? %>
+        <a class="dropdown-item" href="<%= downloads[:ead][:href] %>"><%= t('arclight.views.show.download.ead', size: downloads[:ead][:size]) %></a>
+      <% end  %>
+    </div>
+  </div>
+</li>
+<% end %>

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -14,6 +14,7 @@
           <%= t 'arclight.views.show.no_contents' %>
         </a>
       </li>
+      <%= render partial: 'collection_downloads', locals: { downloads: collection_downloads(document) } %>
     </ul>
     <div class='tab-content'>
       <div class='tab-pane active' id='overview' role='tabpanel'>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -49,6 +49,10 @@ en:
           component_field: 'About this %{level}'
           collection_context_field: 'Collection Context'
         our_collections: 'Our Collections'
+        download:
+          default: 'Download'
+          pdf: 'Collection PDF (%{size})'
+          ead: 'Collection EAD (%{size})'
       repositories:
         number_of_collections:
           zero: 'No collections'

--- a/lib/generators/arclight/install_generator.rb
+++ b/lib/generators/arclight/install_generator.rb
@@ -51,5 +51,9 @@ module Arclight
     def add_repository_config
       copy_file 'config/repositories.yml' unless File.exist?('config/repositories.yml')
     end
+
+    def add_download_config
+      copy_file 'config/downloads.yml' unless File.exist?('config/downloads.yml')
+    end
   end
 end

--- a/lib/generators/arclight/templates/config/downloads.yml
+++ b/lib/generators/arclight/templates/config/downloads.yml
@@ -1,0 +1,13 @@
+#
+# downloads.yml - Use the EAD's <unitid> as the primary key and
+#                 provide the PDF and/or EAD (.xml) links. The
+#                 size value should be a String (shown as-is) or
+#                 the number of bytes in the download.
+#
+sample_unitid:
+  pdf:
+    href: 'http://example.com/sample.pdf'
+    size: '1.23MB'
+  ead:
+    href: 'http://example.com/sample.xml'
+    size: 123456

--- a/spec/fixtures/config/downloads.yml
+++ b/spec/fixtures/config/downloads.yml
@@ -1,0 +1,14 @@
+#
+# downloads.yml - Use the EAD's <unitid> as the primary key and
+#                 provide the PDF and/or EAD (.xml) links. The
+#                 size value should be a String (shown as-is) or
+#                 the number of bytes in the download.
+#
+#
+MS C 271:
+  pdf:
+    href: 'http://example.com/MS+C+271.pdf'
+    size: '1.23MB'
+  ead:
+    href: 'http://example.com/MS+C+271.xml'
+    size: 123456

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -201,4 +201,29 @@ RSpec.describe ArclightHelper, type: :helper do
       expect(helper.hierarchy_component_context?).to be_falsey
     end
   end
+  context '#collection_downloads' do
+    let(:document) { SolrDocument.new('unitid_ssm' => 'MS C 271') }
+    let(:config_file) { File.join('spec', 'fixtures', 'config', 'downloads.yml') }
+    let(:config_data) { YAML.safe_load(File.read(config_file)) }
+
+    it 'no download metadata' do
+      allow(File).to receive(:read).and_raise(Errno::ENOENT)
+      expect(helper.collection_downloads(document)).to eq({})
+    end
+    it 'handles no downloads' do
+      expect(helper.collection_downloads(document, {})).to eq({})
+    end
+    it 'handles PDF downloads' do
+      expect(helper.collection_downloads(document, config_data)[:pdf]).to include(
+        href: 'http://example.com/MS+C+271.pdf',
+        size: '1.23MB'
+      )
+    end
+    it 'handles EAD downloads' do
+      expect(helper.collection_downloads(document, config_data)[:ead]).to include(
+        href: 'http://example.com/MS+C+271.xml',
+        size: '121 KB'
+      )
+    end
+  end
 end

--- a/spec/views/_collection_downloads.html.erb_spec.rb
+++ b/spec/views/_collection_downloads.html.erb_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'catalog/_collection_downloads', type: :view do
+  context 'when on collection show page' do
+    let(:pdf_data) { { href: '/documents/abc123.pdf', size: 123 } }
+    let(:ead_data) { { href: '/documents/abc123.xml', size: 456 } }
+    let(:downloads) { { pdf: pdf_data, ead: ead_data } }
+
+    before do
+      allow(view).to receive(:downloads).and_return(downloads)
+      render
+    end
+
+    context 'with both downloads' do
+      it 'shows the menu items' do
+        expect(rendered).to have_css('.dropdown')
+        expect(rendered).to have_css('button', text: 'Download')
+        expect(rendered).to have_css('a', text: 'Collection PDF (123)')
+        expect(rendered).to have_css('a[@href="/documents/abc123.pdf"]')
+        expect(rendered).to have_css('a', text: 'Collection EAD (456)')
+        expect(rendered).to have_css('a[@href="/documents/abc123.xml"]')
+      end
+    end
+    context 'with PDF download' do
+      let(:ead_data) { {} }
+
+      it 'shows the menu item' do
+        expect(rendered).to have_css('.dropdown')
+        expect(rendered).to have_css('a', text: 'Collection PDF (123)')
+        expect(rendered).not_to have_css('a', text: 'Collection EAD (456)')
+      end
+    end
+    context 'with EAD download' do
+      let(:pdf_data) { {} }
+
+      it 'shows the menu item' do
+        expect(rendered).to have_css('.dropdown')
+        expect(rendered).not_to have_css('a', text: 'Collection PDF (123)')
+        expect(rendered).to have_css('a', text: 'Collection EAD (456)')
+      end
+    end
+    context 'with no downloads' do
+      let(:pdf_data) { {} }
+      let(:ead_data) { {} }
+
+      it 'omits the dropdown' do
+        expect(rendered).not_to have_css '.dropdown'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes #371 by adding a dropdown menu on the Collection show page for downloading any PDF or EAD (.xml) files found in the `config/downloads.yml` metadata. The dropdown only has entries for downloads that are present (i.e., if there's only a PDF configured then the dropdown is just the PDF). If there's no downloads available, it omits the dropdown entirely.

![screen shot 2017-05-30 at 2 21 26 pm](https://cloud.githubusercontent.com/assets/1861171/26607165/05738c00-454a-11e7-81dd-d500804df9fd.png)

The `config/downloads.yml` for the above screenshot would look like this: note both `:href` and `:size` are required:

```yml
M0198:
  pdf:
    href: 'http://example.com/M0198.pdf'
    size: '5 MB'
  ead:
    href: '/documents/M0198.xml'
    size: '30 KB'
```