### PR TITLE
Fix highlighting of siblings in Collection Context on Component page

### DIFF
--- a/app/assets/javascripts/arclight/collection_navigation.js
+++ b/app/assets/javascripts/arclight/collection_navigation.js
@@ -4,30 +4,35 @@
    * Converts documents that should be used in a hierarchy, to highlighted
    * localized siblings.
    */
-  function convertDocsForContext(parsedHighlightText, $doc) {
+  function convertDocsForContext(id, $doc) {
     var newDocs;
     var $currentDoc;
     var $previousDocs;
     var $nextDocs;
-    $currentDoc = $doc.find('article:contains(' + parsedHighlightText + ')');
+    var headers = $doc.find('article header[data-document-id="' + id + '"]')
+    if (headers.length == 0) {
+      $.error('Document is missing id=' + id);
+    }
+    $currentDoc = $(headers[0].parentNode); // need article element
     $currentDoc.addClass('al-hierarchy-highlight');
 
+    // We want to show 0-1 or 0-2 siblings depending on where highlighted component is
     $previousDocs = $currentDoc.prevUntil().slice(0, 2);
     $nextDocs = $currentDoc.nextUntil().slice(0, 2);
 
-    // Case where there are siblings on both sides
     if ($previousDocs.length > 0 && $nextDocs.length > 0) {
+      // Case where there are siblings on both sides, show 1 each
       newDocs = $('<div>');
       newDocs.append($previousDocs.first());
       newDocs.append($currentDoc);
       newDocs.append($nextDocs.first());
     } else if ($previousDocs.length > 0) {
-      // Case where there are only previous siblings
+      // Case where there are only previous siblings, show 2 of them
       newDocs = $('<div>');
-      newDocs.append($previousDocs);
+      newDocs.append($previousDocs.get().reverse()); // previous is not in the order we need
       newDocs.append($currentDoc);
     } else {
-      // Case where there are only next siblings
+      // Case where there are only next siblings, show 2 of them
       newDocs = $('<div>');
       newDocs.append($currentDoc);
       newDocs.append($nextDocs);
@@ -66,12 +71,9 @@
         var showDocs = $doc.find('article.document');
         var newDocs = $doc.find('#documents');
 
-        // Add a highlight class here for containing text. We need to parse the
-        // area for text as it is potentially encoded. This is also the case
-        // that we only want to include localized siblings
-        var parsedHighlightText = $('<textarea/>').html(data.arclight.highlight).val();
-        if (parsedHighlightText) {
-          newDocs = convertDocsForContext(parsedHighlightText, $doc);
+        // Add a highlight class for the article matching the highlight id
+        if (data.arclight.highlightId) {
+          newDocs = convertDocsForContext(data.arclight.highlightId, $doc);
         }
 
         $el.hide().html(newDocs).fadeIn(500);

--- a/app/views/catalog/_component_overview.html.erb
+++ b/app/views/catalog/_component_overview.html.erb
@@ -38,7 +38,7 @@
         path: search_catalog_path(hierarchy_context: 'component'),
         name: @document.collection_name,
         parent: @document.parent_ids.last,
-        highlight: show_presenter(@document).heading
+        highlightId: @document.id
       }
     }
   ) %>

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -1,5 +1,5 @@
 <%# header bar for doc items in index view -%>
-<header class="documentHeader row">
+<header class="documentHeader row" data-document-id="<%= document.id %>">
   <h3 class="index_title document-title-heading col-md-12">
     <% counter = document_counter_with_offset(document_counter) %>
     <%= link_to_document document, document_show_link_field(document), counter: counter %>

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -1,4 +1,4 @@
-<header class="documentHeader row">
+<header class="documentHeader row" data-document-id="<%= document.id %>">
   <% requestable = item_requestable?('', { document: document }) %>
   <% side_content = document.children? || requestable %>
   <h3 class="index_title document-title-heading <%= side_content ? 'col-md-9' : 'col-md-12' %> ">

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -94,15 +94,54 @@ RSpec.describe 'Component Page', type: :feature do
         end
       end
     end
-    it 'has siblings and highlighted self' do
-      within '#collection-context' do
-        within '.al-contents' do
-          expect(page).to have_css(
-            '.al-hierarchy-highlight h3',
-            text: /"A brief account of the origin/
-          )
-          expect(page).to have_css 'article', text: 'Statements of purpose, c.1902'
-          expect(page).to have_css 'article', text: 'Constitution - notes on drafting of constitution, c.1902-1903'
+    context 'siblings and highlighted self' do
+      it 'has next 2 siblings -- i.e., at beginning' do
+        within '#collection-context' do
+          within '.al-contents' do
+            expect(page).to have_css(
+              'article:nth-child(1).al-hierarchy-highlight h3',
+              text: /"A brief account of the origin/
+            )
+            expect(page).to have_css 'article:nth-child(2)', text: 'Statements of purpose, c.1902'
+            expect(page).to have_css 'article:nth-child(3)',
+                                     text: 'Constitution - notes on drafting of constitution, c.1902-1903'
+            expect(page).to have_css 'article', count: 3
+          end
+        end
+      end
+      context '2 prev siblings only' do
+        let(:doc_id) { 'aoa271aspace_4365cd1ed8bd8fee1bac6077a4d81359' }
+
+        it 'is at the end' do
+          within '#collection-context' do
+            within '.al-contents' do
+              expect(page).to have_css(
+                'article:nth-child(3).al-hierarchy-highlight h3',
+                text: 'General announcements, 1909-1967'
+              )
+              expect(page).to have_css 'article:nth-child(1)', text: 'Meetings'
+              expect(page).to have_css 'article:nth-child(2)', text: 'Financial Records'
+              expect(page).to have_css 'article', count: 3
+            end
+          end
+        end
+      end
+      context 'prev and next sibling' do
+        let(:doc_id) { 'aoa271aspace_e6db65d47e891d61d69c2798c68a8f02' }
+
+        it 'is in the middle' do
+          within '#collection-context' do
+            within '.al-contents' do
+              expect(page).to have_css(
+                'article:nth-child(2).al-hierarchy-highlight h3',
+                text: /Statements of purpose/
+              )
+              expect(page).to have_css 'article:nth-child(1)', text: /"A brief account of the origin/
+              expect(page).to have_css 'article:nth-child(3)',
+                                       text: 'Constitution - notes on drafting of constitution, c.1902-1903'
+              expect(page).to have_css 'article', count: 3
+            end
+          end
         end
       end
     end
@@ -138,6 +177,15 @@ RSpec.describe 'Component Page', type: :feature do
       it 'only has one component at level 4' do
         within '#collection-context .al-contents.al-hierarchy-level-4' do
           expect(page).to have_css 'h3', text: 'Building Plans', count: 1
+        end
+      end
+    end
+    context 'duplicate titles' do
+      let(:doc_id) { 'lc0100aspace_c5ef89d4ae68bb77e7c641f3edb3f1c8' }
+
+      it 'does not highlight duplicate titles' do
+        within '#collection-context .al-hierarchy-highlight' do
+          expect(page).to have_css 'h3', text: 'Item AA201', count: 1
         end
       end
     end

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -132,10 +132,13 @@ RSpec.describe 'Component Page', type: :feature do
         expect(page).to have_css 'article', text: 'Constitution and by-laws - drafts, 1902-1904'
       end
     end
-    it 'ancestor list does not contain cousins' do
-      visit solr_document_path 'aoa271aspace_e8755922a9336970292ca817983e7139'
-      within '#collection-context .al-contents.al-hierarchy-level-4' do
-        expect(page).to have_css 'h3', count: 1
+    context 'ancestor list does not contain cousins' do
+      let(:doc_id) { 'aoa271aspace_e8755922a9336970292ca817983e7139' }
+
+      it 'only has one component at level 4' do
+        within '#collection-context .al-contents.al-hierarchy-level-4' do
+          expect(page).to have_css 'h3', text: 'Building Plans', count: 1
+        end
       end
     end
   end

--- a/spec/features/many_component_ead_spec.rb
+++ b/spec/features/many_component_ead_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Many component EAD', type: :feature do
       within '#contents' do
         click_link 'View'
         within '#aspace_327a75c226d44aa1a769edb4d2f13c6e-collapsible-hierarchy' do
-          expect(page).to have_css '.blacklight-item', count: 201
+          expect(page).to have_css '.blacklight-item', count: 202
         end
       end
     end

--- a/spec/fixtures/ead/sample/large-components-list.xml
+++ b/spec/fixtures/ead/sample/large-components-list.xml
@@ -1044,6 +1044,11 @@
             <unittitle>Item AA201</unittitle>
           </did>
         </c>
+        <c id="aspace_1d6609b84353d5091c36e5fa98306bc0" level="item">
+          <did>
+            <unittitle>Item AA201</unittitle><!-- need duplicate title -->
+          </did>
+        </c>
       </c>
       <c id="aspace_6ae90875c59eed6d2ce30294c8cfb873" level="file">
         <did>


### PR DESCRIPTION
This PR fixes #434. To fix the bug with highlighting multiple items, I switched the highlight detection to use `document.id` rather than text parsing the titles to do the matching. This is now done via `data-document-id`. Also, I found a bug that was causing the previous 2 siblings to be inverted when we're highlighting the last item. I updated the tests to handle the first/middle/last cases and specific ordering to test for possible regressions on both these bugs.

### First item highlighted
![screen shot 2017-06-01 at 3 32 19 pm](https://cloud.githubusercontent.com/assets/1861171/26703665/9fcfe1c2-46df-11e7-8ffc-3ca070567d0c.png)

### Middle item highlighted -- note intentional duplicate titles 

![screen shot 2017-06-01 at 3 32 45 pm](https://cloud.githubusercontent.com/assets/1861171/26703666/a204b1c0-46df-11e7-8c58-01dbe4458e80.png)

### Last item highlighted -- note intentional duplicate titles 

![screen shot 2017-06-01 at 3 32 55 pm](https://cloud.githubusercontent.com/assets/1861171/26703668/a3dd9296-46df-11e7-8057-f495e8a405ff.png)
