### PR TITLE
Move collection and component embedded viewer to online content tab

### DIFF
--- a/app/assets/javascripts/arclight/oembed_viewer.js
+++ b/app/assets/javascripts/arclight/oembed_viewer.js
@@ -1,29 +1,38 @@
 Blacklight.onLoad(function () {
   'use strict';
+  var onlineContentTabSelector = '[data-arclight-online-content-tab="true"]';
+  var oEmbedViewerSelector = '[data-arclight-oembed="true"]';
 
-  $('[data-arclight-oembed="true"]').each(function (i, element) {
-    var $el = $(element);
-    var data = $el.data();
-    var resourceUrl = data.arclightOembedUrl;
-    $.ajax({
-      url: resourceUrl,
-      dataType: 'html'
-    }).done(function (response) {
-      var links = $('<div>' + response.match(/<link .*>/g).join('') + '</div>'); // Parse out link elements so image assets are not loaded
-      var oEmbedEndPoint = links.find('link[rel="alternate"][type="application/json+oembed"]').prop('href');
+  $(onlineContentTabSelector).on('shown.bs.tab', function() {
+    var $viewerElements = $(oEmbedViewerSelector);
+    if($viewerElements.length === 0) {
+      return;
+    }
 
-      if(!oEmbedEndPoint || oEmbedEndPoint.length === 0) {
-        return;
-      }
-
+    $viewerElements.each(function (i, element) {
+      var $el = $(element);
+      var data = $el.data();
+      var resourceUrl = data.arclightOembedUrl;
       $.ajax({
-        url: oEmbedEndPoint
-      }).done(function (oEmbedResponse) {
-        if(oEmbedResponse.html) {
-          $el.hide()
-             .html(oEmbedResponse.html)
-             .fadeIn(500);
+        url: resourceUrl,
+        dataType: 'html'
+      }).done(function (response) {
+        var links = $('<div>' + response.match(/<link .*>/g).join('') + '</div>'); // Parse out link elements so image assets are not loaded
+        var oEmbedEndPoint = links.find('link[rel="alternate"][type="application/json+oembed"]').prop('href');
+
+        if(!oEmbedEndPoint || oEmbedEndPoint.length === 0) {
+          return;
         }
+
+        $.ajax({
+          url: oEmbedEndPoint
+        }).done(function (oEmbedResponse) {
+          if(oEmbedResponse.html) {
+            $el.hide()
+               .html(oEmbedResponse.html)
+               .fadeIn(500);
+          }
+        });
       });
     });
   });

--- a/app/controllers/concerns/arclight/field_config_helpers.rb
+++ b/app/controllers/concerns/arclight/field_config_helpers.rb
@@ -10,7 +10,6 @@ module Arclight
 
     included do
       if respond_to?(:helper_method)
-        helper_method :context_sidebar_digital_object
         helper_method :repository_config_present
         helper_method :request_config_present
         helper_method :context_sidebar_repository
@@ -21,15 +20,6 @@ module Arclight
         helper_method :paragraph_separator
         helper_method :link_to_name_facet
       end
-    end
-
-    def context_sidebar_digital_object(args)
-      document = args[:document]
-      ApplicationController.renderer.render(
-        'arclight/digital_objects/_sidebar_section',
-        layout: false,
-        locals: { digital_objects: document.digital_objects }
-      )
     end
 
     def repository_config_present(_, document)

--- a/app/views/arclight/digital_objects/_sidebar_section.html.erb
+++ b/app/views/arclight/digital_objects/_sidebar_section.html.erb
@@ -1,6 +1,0 @@
-<% digital_objects.each do |object| %>
-  <div class='al-digital-object'>
-    <div class='al-digital-object-label'><%= object.label %></div>
-    <%= link_to(t(:'.link'), object.href, class: 'btn btn-sm btn-primary', role: 'button') %>
-  </div>
-<% end %>

--- a/app/views/arclight/viewers/_oembed.html.erb
+++ b/app/views/arclight/viewers/_oembed.html.erb
@@ -1,9 +1,7 @@
 <% viewer.resources.each do |resource| %>
-  <%= content_tag(
-        :div, '',
-        class: 'al-oembed-viewer',
-        'data-arclight-oembed': true,
-        'data-arclight-oembed-url': resource.href
-      )
-  %>
+  <%= content_tag(:div, viewer.attributes_for(resource)) do %>
+    <div class='al-digital-object'>
+      <%= link_to(resource.label, resource.href) %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/catalog/_arclight_viewer_collection.html.erb
+++ b/app/views/catalog/_arclight_viewer_collection.html.erb
@@ -1,1 +1,0 @@
-<% # intentionally left blank to remove the arclight viewer from the collection view %>

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -14,6 +14,15 @@
           <%= t 'arclight.views.show.no_contents' %>
         </a>
       </li>
+      <li class='nav-item'>
+        <a class='nav-link <%= 'disabled' unless document.digital_objects.present? %>' data-toggle='pill' href='#online-content' role='tab'>
+          <% if document.digital_objects.present? %>
+            <%= t 'arclight.views.show.online_content' %>
+          <% else %>
+            <%= t 'arclight.views.show.no_online_content' %>
+          <% end %>
+        </a>
+      </li>
       <%= render partial: 'collection_downloads', locals: { downloads: collection_downloads(document) } %>
     </ul>
     <div class='tab-content'>
@@ -22,6 +31,9 @@
       </div>
       <div class='tab-pane' id='contents' role='tabpanel'>
         <%= render 'collection_contents' %>
+      </div>
+      <div class='tab-pane' id='online-content' role='tabpanel'>
+         <%= render_document_partial(document, 'arclight_viewer') %>
       </div>
     </div>
   </div>

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -15,7 +15,7 @@
         </a>
       </li>
       <li class='nav-item'>
-        <a class='nav-link <%= 'disabled' unless document.digital_objects.present? %>' data-toggle='pill' href='#online-content' role='tab'>
+        <a class='nav-link <%= 'disabled' unless document.digital_objects.present? %>' data-toggle='pill' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
           <% if document.digital_objects.present? %>
             <%= t 'arclight.views.show.online_content' %>
           <% else %>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -10,7 +10,7 @@
         </a>
       </li>
       <li class='nav-item'>
-        <a class='nav-link <%= 'disabled' unless document.online_content? %>' data-toggle='pill' href='#online-content' role='tab'>
+        <a class='nav-link <%= 'disabled' unless document.online_content? %>' data-toggle='pill' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
           <% if document.online_content? %>
             <%= t 'arclight.views.show.online_content' %>
           <% else %>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -3,6 +3,30 @@
     <%= render partial: 'show_component_sidebar' %>
   </div>
   <div class='col-md-9'>
-    <%= render 'component_overview' %>
+    <ul class='nav nav-pills' role='tablist'>
+      <li class='nav-item'>
+        <a class='nav-link active' data-toggle='pill' href='#overview' role='tab'>
+          <%= t 'arclight.views.show.overview' %>
+        </a>
+      </li>
+      <li class='nav-item'>
+        <a class='nav-link <%= 'disabled' unless document.online_content? %>' data-toggle='pill' href='#online-content' role='tab'>
+          <% if document.online_content? %>
+            <%= t 'arclight.views.show.online_content' %>
+          <% else %>
+            <%= t 'arclight.views.show.no_online_content' %>
+          <% end %>
+        </a>
+      </li>
+    </ul>
+    <div class='tab-content'>
+      <div class='tab-pane active' id='overview' role='tabpanel'>
+        <%= render 'component_overview' %>
+      </div>
+      <div class='tab-pane' id='online-content' role='tabpanel'>
+        <%= render_document_partial(document, 'arclight_viewer') %>
+      </div>
+    </div>
   </div>
+
 </div>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -25,6 +25,8 @@ en:
       show:
         collection_id: 'Collection ID: %{id}'
         overview: 'Overview'
+        online_content: 'Online content'
+        no_online_content: 'No online content'
         no_contents: 'No content inventory'
         search_within: 'Search within this collection'
         navigation_sidebar:

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -3,9 +3,6 @@ en:
     masthead_heading: 'Archival Collections at Institution'
     date_range_histogram:
       show_hide: 'Show/hide date distribution'
-    digital_objects:
-      sidebar_section:
-        link: 'Open viewer'
     hierarchy:
       view_all: 'View'
       scope_and_contents: 'Scope and Contents'
@@ -33,7 +30,6 @@ en:
         navigation_sidebar:
           title: 'Navigation overview'
         context_sidebar:
-          online_field: 'Online'
           in_person_field: 'In person'
           terms_field: 'Terms & Conditions'
           cite_field: 'How to cite this collection'

--- a/lib/arclight/digital_object.rb
+++ b/lib/arclight/digital_object.rb
@@ -6,7 +6,7 @@ module Arclight
   class DigitalObject
     attr_reader :label, :href
     def initialize(label:, href:)
-      @label = label
+      @label = label.present? ? label : href
       @href = href
     end
 

--- a/lib/arclight/digital_object.rb
+++ b/lib/arclight/digital_object.rb
@@ -18,5 +18,9 @@ module Arclight
       object_data = JSON.parse(json)
       new(label: object_data['label'], href: object_data['href'])
     end
+
+    def ==(other)
+      href == other.href && label == other.label
+    end
   end
 end

--- a/lib/arclight/viewers/oembed.rb
+++ b/lib/arclight/viewers/oembed.rb
@@ -22,11 +22,16 @@ module Arclight
       end
 
       def resources
-        document.digital_objects.reject do |object|
-          exclude_patterns.any? do |pattern|
-            object.href =~ pattern
-          end
-        end
+        document.digital_objects
+      end
+
+      def embeddable?(resource)
+        embeddable_resources.include?(resource)
+      end
+
+      def attributes_for(resource)
+        return {} unless embeddable?(resource)
+        { class: 'al-oembed-viewer', 'data-arclight-oembed': true, 'data-arclight-oembed-url': resource.href }
       end
 
       def to_partial_path
@@ -37,6 +42,14 @@ module Arclight
 
       def exclude_patterns
         Arclight::Engine.config.oembed_resource_exclude_patterns
+      end
+
+      def embeddable_resources
+        document.digital_objects.reject do |object|
+          exclude_patterns.any? do |pattern|
+            object.href =~ pattern
+          end
+        end
       end
     end
   end

--- a/lib/arclight/viewers/oembed.rb
+++ b/lib/arclight/viewers/oembed.rb
@@ -26,7 +26,7 @@ module Arclight
       end
 
       def embeddable?(resource)
-        embeddable_resources.include?(resource)
+        resource == resources.first && embeddable_resources.include?(resource)
       end
 
       def attributes_for(resource)

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -299,8 +299,6 @@ class CatalogController < ApplicationController
       config.view_config(:show).document_actions.delete(action)
     end
 
-    # Insert the viewer between the header and the content
-    config.show.partials.insert(1, :arclight_viewer)
     # Insert the breadcrumbs at the beginning
     config.show.partials.unshift(:show_breadcrumbs)
 

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -193,7 +193,6 @@ class CatalogController < ApplicationController
     ]
 
     config.show.context_sidebar_items = [
-      :online_field,
       :in_person_field,
       :terms_field,
       :cite_field
@@ -204,7 +203,6 @@ class CatalogController < ApplicationController
     ]
 
     config.show.component_sidebar_items = [
-      :online_field,
       :in_person_field,
       :component_terms_field,
       :cite_field
@@ -239,9 +237,6 @@ class CatalogController < ApplicationController
     config.add_summary_field 'extent_ssm', label: 'Extent'
     config.add_summary_field 'language_ssm', label: 'Language'
     config.add_summary_field 'prefercite_ssm', label: 'Preferred citation'
-
-    # Collection Show Page - Online Section
-    config.add_online_field 'digital_objects_ssm', label: 'Access this item', helper_method: :context_sidebar_digital_object
 
     # Collection Show Page - In Person Section
     config.add_in_person_field 'id', if: :before_you_visit_note_present, label: 'Before you visit', helper_method: :context_sidebar_visit_note # Using ID because we know it will always exist

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -177,17 +177,6 @@ RSpec.describe 'Collection Page', type: :feature do
         end
       end
 
-      it 'has an online card' do
-        within('#accordion') do
-          expect(page).to have_css('h3', text: 'Online')
-          # Blacklight renders the dt and it is not necessary in our display
-          expect(page).to have_css('dt', visible: false)
-
-          expect(page).to have_css('.al-digital-object-label', text: 'History slideshow')
-          expect(page).to have_css('.btn-primary', text: 'Open viewer')
-        end
-      end
-
       it 'has a terms and conditions card' do
         within '#accordion' do
           expect(page).to have_css '.card-header h3', text: 'Terms & Conditions'

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -233,6 +233,13 @@ RSpec.describe 'Collection Page', type: :feature do
         expect(page).to have_css '#overview', visible: true
         expect(page).to have_css '#contents', visible: false
       end
+      it 'clicking online contents toggles visibility', js: true do
+        expect(page).to have_css '#overview', visible: true
+        expect(page).to have_css '#online-content', visible: false
+        click_link 'Online content'
+        expect(page).to have_css '#overview', visible: false
+        expect(page).to have_css '#online-content', visible: true
+      end
       it 'contents contain linked level 1 components' do
         within '#contents' do
           click_link 'Series I: Administrative Records, 1902-1976'

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -217,6 +217,34 @@ RSpec.describe 'Collection Page', type: :feature do
     end
   end
 
+  describe 'tabbed display' do
+    context 'collection has online content', js: true do
+      it 'clicking contents toggles visibility' do
+        click_link 'Contents'
+        expect(page).to have_css '#contents', visible: true
+        expect(page).to have_css '#overview', visible: false
+        click_link 'Overview'
+        expect(page).to have_css '#overview', visible: true
+        expect(page).to have_css '#contents', visible: false
+      end
+      it 'clicking online contents toggles visibility' do
+        expect(page).to have_css '#overview', visible: true
+        expect(page).to have_css '#online-content', visible: false
+        click_link 'Online content'
+        expect(page).to have_css '#overview', visible: false
+        expect(page).to have_css '#online-content', visible: true
+      end
+    end
+
+    context 'collection has no online content' do
+      let(:doc_id) { 'm0198-xml' }
+
+      it 'displays a disabled tab' do
+        expect(page).to have_css 'a.nav-link.disabled', text: 'No online content'
+      end
+    end
+  end
+
   describe 'overview and contents' do
     it 'contents are not visible by default' do
       expect(page).to have_css '#contents', visible: false
@@ -226,20 +254,6 @@ RSpec.describe 'Collection Page', type: :feature do
     end
     describe 'interactions', js: true do
       before { click_link 'Contents' }
-      it 'clicking contents toggles visibility' do
-        expect(page).to have_css '#contents', visible: true
-        expect(page).to have_css '#overview', visible: false
-        click_link 'Overview'
-        expect(page).to have_css '#overview', visible: true
-        expect(page).to have_css '#contents', visible: false
-      end
-      it 'clicking online contents toggles visibility', js: true do
-        expect(page).to have_css '#overview', visible: true
-        expect(page).to have_css '#online-content', visible: false
-        click_link 'Online content'
-        expect(page).to have_css '#overview', visible: false
-        expect(page).to have_css '#online-content', visible: true
-      end
       it 'contents contain linked level 1 components' do
         within '#contents' do
           click_link 'Series I: Administrative Records, 1902-1976'

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -7,11 +7,49 @@ RSpec.describe 'Component Page', type: :feature do
 
   before { visit solr_document_path(id: doc_id) }
 
-  describe 'Viewer section' do
-    let(:doc_id) { 'a0011-xmlaspace_ref6_lx4' }
+  describe 'tabbed display' do
+    it 'clicking contents toggles visibility', js: true do
+      expect(page).to have_css '#overview', visible: true
+      expect(page).to have_css '#online-content', visible: false
+      click_link 'Online content'
+      expect(page).to have_css '#overview', visible: false
+      expect(page).to have_css '#online-content', visible: true
+    end
+  end
 
-    it 'renders digital object viewer initialization markup' do
-      expect(page).to have_css('.al-oembed-viewer[data-arclight-oembed-url="http://purl.stanford.edu/kc844kt2526"]')
+  describe 'Viewer section' do
+    context 'embedded content' do
+      let(:doc_id) { 'a0011-xmlaspace_ref6_lx4' }
+
+      it 'renders digital object viewer initialization markup', js: true do
+        expect(page).to have_css(
+          '.al-oembed-viewer[data-arclight-oembed-url="http://purl.stanford.edu/kc844kt2526"]',
+          visible: false
+        )
+        click_link('Online content')
+        expect(page).to have_css(
+          '.al-oembed-viewer[data-arclight-oembed-url="http://purl.stanford.edu/kc844kt2526"]',
+          visible: true
+        )
+      end
+    end
+
+    context 'non-embeddable content' do
+      let(:doc_id) { 'aoa271aspace_843e8f9f22bac69872d0802d6fffbb04' }
+
+      it 'renders a list of links', js: true do
+        click_link('Online content')
+        expect(page).to have_link('Folder of digitized stuff')
+        expect(page).to have_css('a', text: /^Letter from Christian B. Anfinsen/)
+      end
+    end
+
+    context 'no content' do
+      let(:doc_id) { 'aoa271aspace_a951375d104030369a993ff943f61a77' }
+
+      it 'renders disabled tab' do
+        expect(page).to have_css('.nav-link.disabled', text: 'No online content')
+      end
     end
   end
 

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -17,42 +17,6 @@ RSpec.describe 'Component Page', type: :feature do
     end
   end
 
-  describe 'Viewer section' do
-    context 'embedded content' do
-      let(:doc_id) { 'a0011-xmlaspace_ref6_lx4' }
-
-      it 'renders digital object viewer initialization markup', js: true do
-        expect(page).to have_css(
-          '.al-oembed-viewer[data-arclight-oembed-url="http://purl.stanford.edu/kc844kt2526"]',
-          visible: false
-        )
-        click_link('Online content')
-        expect(page).to have_css(
-          '.al-oembed-viewer[data-arclight-oembed-url="http://purl.stanford.edu/kc844kt2526"]',
-          visible: true
-        )
-      end
-    end
-
-    context 'non-embeddable content' do
-      let(:doc_id) { 'aoa271aspace_843e8f9f22bac69872d0802d6fffbb04' }
-
-      it 'renders a list of links', js: true do
-        click_link('Online content')
-        expect(page).to have_link('Folder of digitized stuff')
-        expect(page).to have_css('a', text: /^Letter from Christian B. Anfinsen/)
-      end
-    end
-
-    context 'no content' do
-      let(:doc_id) { 'aoa271aspace_a951375d104030369a993ff943f61a77' }
-
-      it 'renders disabled tab' do
-        expect(page).to have_css('.nav-link.disabled', text: 'No online content')
-      end
-    end
-  end
-
   describe 'Component section heading' do
     it 'includes the level' do
       expect(page).to have_css('h3.al-show-sub-heading', text: 'About this file')

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -37,20 +37,6 @@ RSpec.describe 'Component Page', type: :feature do
   end
 
   describe 'sidebar' do
-    it 'includes an online section when the component includes a DAO' do
-      within('.al-sticky-sidebar') do
-        expect(page).to have_css('h3', text: 'Online')
-        # Blacklight renders the dt and it is not necessary in our display
-        expect(page).to have_css('dt', visible: false)
-
-        expect(page).to have_css('.al-digital-object', count: 2)
-
-        expect(page).to have_css('.al-digital-object-label', text: 'Folder of digitized stuff')
-        expect(page).to have_css('.al-digital-object-label', text: /^Letter from Christian B\. Anfinsen/)
-        expect(page).to have_css('.btn-primary', text: 'Open viewer', count: 2)
-      end
-    end
-
     describe 'context_sidebar' do
       context 'that has restrictions and terms of access' do
         it 'has a terms and conditions card' do

--- a/spec/features/viewer_spec.rb
+++ b/spec/features/viewer_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Online Content', type: :feature do
+  let(:doc_id) { 'aoa271aspace_843e8f9f22bac69872d0802d6fffbb04' }
+
+  before { visit solr_document_path(id: doc_id) }
+
+  describe 'Viewer' do
+    context 'embedded content' do
+      let(:doc_id) { 'a0011-xmlaspace_ref6_lx4' }
+
+      it 'renders digital object viewer initialization markup', js: true do
+        expect(page).to have_css(
+          '.al-oembed-viewer[data-arclight-oembed-url="http://purl.stanford.edu/kc844kt2526"]',
+          visible: false
+        )
+        click_link('Online content')
+        expect(page).to have_css(
+          '.al-oembed-viewer[data-arclight-oembed-url="http://purl.stanford.edu/kc844kt2526"]',
+          visible: true
+        )
+      end
+    end
+
+    context 'non-embeddable content' do
+      let(:doc_id) { 'aoa271aspace_843e8f9f22bac69872d0802d6fffbb04' }
+
+      it 'renders a list of links', js: true do
+        click_link('Online content')
+        expect(page).to have_link('Folder of digitized stuff')
+        expect(page).to have_css('a', text: /^Letter from Christian B. Anfinsen/)
+      end
+    end
+
+    context 'no content' do
+      let(:doc_id) { 'aoa271aspace_a951375d104030369a993ff943f61a77' }
+
+      it 'renders disabled tab' do
+        expect(page).to have_css('.nav-link.disabled', text: 'No online content')
+      end
+    end
+  end
+end

--- a/spec/lib/arclight/digital_object_spec.rb
+++ b/spec/lib/arclight/digital_object_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe Arclight::DigitalObject do
     described_class.new(label: 'An object label', href: 'https://example.com/an-object-href')
   end
 
+  describe 'label' do
+    let(:empty_label) do
+      described_class.new(label: '', href: 'https://example.com/an-object-href')
+    end
+
+    it 'uses href if label is blank' do
+      expect(empty_label.href).to eq empty_label.href
+    end
+  end
+
   describe '#to_json' do
     it 'returns a json serialization of the object' do
       json = JSON.parse(instance.to_json)

--- a/spec/lib/arclight/digital_object_spec.rb
+++ b/spec/lib/arclight/digital_object_spec.rb
@@ -22,4 +22,22 @@ RSpec.describe Arclight::DigitalObject do
       expect(deserialized.label).to eq 'An object label'
     end
   end
+
+  describe '==' do
+    let(:dissimilar) do
+      described_class.new(label: 'A different label', href: 'https://example.com/an-object-href')
+    end
+
+    let(:similar) do
+      described_class.new(label: 'An object label', href: 'https://example.com/an-object-href')
+    end
+
+    it 'is true when href and label are similar' do
+      expect(instance).not_to eq dissimilar
+    end
+
+    it 'is false when objects have dissimilar labels' do
+      expect(instance).to eq similar
+    end
+  end
 end

--- a/spec/lib/arclight/viewers/oembed_spec.rb
+++ b/spec/lib/arclight/viewers/oembed_spec.rb
@@ -17,17 +17,45 @@ RSpec.describe Arclight::Viewers::OEmbed do
         expect(resource).to be_a Arclight::DigitalObject
       end
     end
+  end
 
-    context 'pattern blacklist' do
-      let(:document) do
-        SolrDocument.new(
-          digital_objects_ssm: [{ href: 'http://example.com/content.pdf' }.to_json]
-        )
-      end
+  describe '#embeddable?' do
+    let(:document) do
+      SolrDocument.new(
+        digital_objects_ssm: [
+          { href: 'http://example.com/content.pdf' }.to_json,
+          { href: 'http://example.com' }.to_json
+        ]
+      )
+    end
 
-      it 'rejects urls that match the configured patterns' do
-        expect(viewer.resources).to be_empty
-      end
+    it 'is false when url matches exclude patterns' do
+      expect(viewer.embeddable?(document.digital_objects.first)).to be false
+    end
+
+    it 'is true when url does not match exclude patterns' do
+      expect(viewer.embeddable?(document.digital_objects.last)).to be true
+    end
+  end
+
+  describe '#attributes_for' do
+    let(:document) do
+      SolrDocument.new(
+        digital_objects_ssm: [
+          { href: 'http://example.com/content.pdf' }.to_json,
+          { href: 'http://example.com' }.to_json
+        ]
+      )
+    end
+
+    it 'returns a hash with oembed information' do
+      attributes = viewer.attributes_for(document.digital_objects.last)
+      expect(attributes[:'data-arclight-oembed']).to eq true
+    end
+
+    it 'returns an empty hash for non-embeddable objects' do
+      attributes = viewer.attributes_for(document.digital_objects.first)
+      expect(attributes).to be_empty
     end
   end
 

--- a/spec/lib/arclight/viewers/oembed_spec.rb
+++ b/spec/lib/arclight/viewers/oembed_spec.rb
@@ -20,21 +20,37 @@ RSpec.describe Arclight::Viewers::OEmbed do
   end
 
   describe '#embeddable?' do
-    let(:document) do
-      SolrDocument.new(
-        digital_objects_ssm: [
-          { href: 'http://example.com/content.pdf' }.to_json,
-          { href: 'http://example.com' }.to_json
-        ]
-      )
+    context 'all objects are theoretically embeddable' do
+      let(:document) do
+        SolrDocument.new(
+          digital_objects_ssm: [
+            { href: 'http://example.com' }.to_json,
+            { href: 'http://example.com/content' }.to_json
+          ]
+        )
+      end
+
+      it 'is true when the object is first' do
+        expect(viewer.embeddable?(document.digital_objects.first)).to be true
+      end
+
+      it 'is false for subsequent objects' do
+        expect(viewer.embeddable?(document.digital_objects.last)).to be false
+      end
     end
 
-    it 'is false when url matches exclude patterns' do
-      expect(viewer.embeddable?(document.digital_objects.first)).to be false
-    end
+    context 'object is not embeddable due to exclude patterns' do
+      let(:document) do
+        SolrDocument.new(
+          digital_objects_ssm: [
+            { href: 'http://example.com/content.pdf' }.to_json
+          ]
+        )
+      end
 
-    it 'is true when url does not match exclude patterns' do
-      expect(viewer.embeddable?(document.digital_objects.last)).to be true
+      it 'is false when url matches exclude patterns' do
+        expect(viewer.embeddable?(document.digital_objects.first)).to be false
+      end
     end
   end
 
@@ -42,19 +58,19 @@ RSpec.describe Arclight::Viewers::OEmbed do
     let(:document) do
       SolrDocument.new(
         digital_objects_ssm: [
-          { href: 'http://example.com/content.pdf' }.to_json,
-          { href: 'http://example.com' }.to_json
+          { href: 'http://example.com' }.to_json,
+          { href: 'http://example.com/content.pdf' }.to_json
         ]
       )
     end
 
     it 'returns a hash with oembed information' do
-      attributes = viewer.attributes_for(document.digital_objects.last)
+      attributes = viewer.attributes_for(document.digital_objects.first)
       expect(attributes[:'data-arclight-oembed']).to eq true
     end
 
     it 'returns an empty hash for non-embeddable objects' do
-      attributes = viewer.attributes_for(document.digital_objects.first)
+      attributes = viewer.attributes_for(document.digital_objects.last)
       expect(attributes).to be_empty
     end
   end

--- a/spec/models/concerns/arclight/solr_document_spec.rb
+++ b/spec/models/concerns/arclight/solr_document_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Arclight::SolrDocument do
     describe '#digital_object_viewer' do
       it 'renders the appropriate viewer' do
         content = Capybara.string(document.digital_object_viewer)
-        expect(content).to have_css('.al-oembed-viewer', count: 2)
+        expect(content).to have_css('.al-oembed-viewer', count: 1)
       end
     end
 


### PR DESCRIPTION
Closes #416 

Worked on this with @jkeck. This PR does the following:
- removes 'Online' sidebar field
- adds an 'Online content' tab for displaying both embeddable and non-embeddable digital objects at both collection and component level
- displays an object's `href` if label is blank or nil

## Collection View

![collection_online_contents](https://cloud.githubusercontent.com/assets/5402927/26704502/6681167a-46e4-11e7-9abc-eb9d158a39ce.gif)

## Component View

![component_online_contents](https://cloud.githubusercontent.com/assets/5402927/26704507/6afa3164-46e4-11e7-81d8-83c12d3a0dd1.gif)
