### PR TITLE
add bookmark controls to Collection Contents view

### DIFF
--- a/app/assets/javascripts/arclight/collection_navigation.js
+++ b/app/assets/javascripts/arclight/collection_navigation.js
@@ -78,6 +78,7 @@
         if (showDocs.length > 0) {
           $el.trigger('navigation.contains.elements');
         }
+        Blacklight.do_bookmark_toggle_behavior();
       });
     }
   };

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -12,6 +12,11 @@
   </h3>
 
   <div class="al-hierarchy-side-content float-right <%= side_content ? 'col-md-3' : 'col' %> ">
+    <% unless hierarchy_component_context? %>
+      <div class="index-document-functions">
+        <%= render partial: 'catalog/bookmark_control', locals: { document: document } %>
+      </div>
+    <% end %>
     <% if requestable %>
       <%= render partial: 'arclight/requests/google_form', locals: { document: document } %>
     <% end %>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -288,6 +288,9 @@ RSpec.describe 'Collection Page', type: :feature do
           )
         end
       end
+      it 'has bookmark controls' do
+        expect(page).to have_css 'form.bookmark-toggle', count: 7
+      end
 
       it 'clicking contents does not change the session results view context' do
         visit search_catalog_path q: '', search_field: 'all_fields'

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe 'Component Page', type: :feature do
           )
           expect(page).to have_css('.al-number-of-children-badge', text: '25 children')
           expect(page).not_to have_css('.al-number-of-children-badge', text: /View/)
+          expect(page).not_to have_css 'form.bookmark-toggle' # no bookmarks
         end
       end
     end


### PR DESCRIPTION
This PR fixes #443. It adds the bookmark control (checkbox) to each component in the Collection page's Contents view. Note that the Blacklight bookmark control requires JavaScript (which turns the buttons into checkbox UIs) so this PR adds that initializer `Blacklight.do_bookmark_toggle_behavior`

![472ce592-4784-11e7-8d4e-10be926d9298](https://cloud.githubusercontent.com/assets/1861171/26740983/956436cc-478c-11e7-814e-54e0a135d56d.png)