### PR TITLE
Asynchronously grab collection components that have digital objects…

### DIFF
--- a/app/assets/javascripts/arclight/collection_navigation.js
+++ b/app/assets/javascripts/arclight/collection_navigation.js
@@ -61,9 +61,11 @@
         url: data.arclight.path,
         data: {
           'f[component_level_isim][]': data.arclight.level,
+          'f[has_online_content_ssim][]': data.arclight.access,
           'f[collection_sim][]': data.arclight.name,
           'f[parent_ssi][]': data.arclight.parent,
-          view: 'hierarchy'
+          search_field: data.arclight.search_field,
+          view: data.arclight.view || 'hierarchy'
         }
       }).done(function (response) {
         var resp = $.parseHTML(response);

--- a/app/assets/stylesheets/arclight/application.scss
+++ b/app/assets/stylesheets/arclight/application.scss
@@ -3,7 +3,7 @@
 @import 'variables';
 @import 'modules/collection_search';
 @import 'modules/highlights';
-@import 'modules/hierarchy';
+@import 'modules/hierarchy_and_online_contents';
 @import 'modules/layout';
 @import 'modules/mastheads';
 @import 'modules/repositories.scss';

--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -1,4 +1,5 @@
-.documents-hierarchy {
+.documents-hierarchy,
+.documents-online_contents {
   .document-title-heading {
     font-size: $font-size-h5;
   }
@@ -125,8 +126,11 @@
     font-size: $font-size-h5;
   }
 
-  .documents-hierarchy .documentHeader {
-    margin-top: 1.5rem;
+  .documents-hierarchy,
+  .documents-online_contents {
+    .documentHeader {
+      margin-top: 1.5rem;
+    }
   }
 
   // Top-level context

--- a/app/models/concerns/arclight/catalog.rb
+++ b/app/models/concerns/arclight/catalog.rb
@@ -8,14 +8,14 @@ module Arclight
     # Overriding the Blacklight method so that the hierarchy view does not start
     # a new search session
     def start_new_search_session?
-      params[:view] != 'hierarchy' && super
+      !%w[hierarchy online_contents].include?(params[:view]) && super
     end
 
     ##
     # Overriding the Blacklight method so that hierarchy does not get stored as
     # the preferred view
     def store_preferred_view
-      return if params[:view] == 'hierarchy'
+      return if %w[hierarchy online_contents].include?(params[:view])
       super
     end
   end

--- a/app/views/catalog/_collection_online_contents.html.erb
+++ b/app/views/catalog/_collection_online_contents.html.erb
@@ -1,0 +1,17 @@
+<% if document.digital_objects.present? %>
+  <%= render_document_partial(document, 'arclight_viewer') %>
+<% elsif document.online_content? %>
+  <%= content_tag(
+    :div, '',
+    class: 'al-contents',
+    data: {
+      arclight: {
+        path: search_catalog_path,
+        name: document.collection_name,
+        access: 'online',
+        view: 'online_contents',
+        search_field: 'within_collection'
+      }
+    }
+  ) %>
+<% end %>

--- a/app/views/catalog/_index_header_online_contents_default.html.erb
+++ b/app/views/catalog/_index_header_online_contents_default.html.erb
@@ -1,0 +1,1 @@
+<%= render_document_partial(document, :index_header_hierarchy, document_counter: document_counter) %>

--- a/app/views/catalog/_index_online_contents_default.html.erb
+++ b/app/views/catalog/_index_online_contents_default.html.erb
@@ -1,0 +1,6 @@
+<%= content_tag('div', class: 'al-document-abstract-or-scope', title: document.abstract_or_scope) do %>
+  <%= content_tag(:h4, I18n.t('arclight.hierarchy.scope_and_contents'), class: 'al-hierarchy-sub-heading') %>
+  <%= content_tag('div', 'data-arclight-truncate' => true) do %>
+    <%= document.abstract_or_scope %>
+  <% end %>
+<% end if document.abstract_or_scope %>

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -15,8 +15,8 @@
         </a>
       </li>
       <li class='nav-item'>
-        <a class='nav-link <%= 'disabled' unless document.digital_objects.present? %>' data-toggle='pill' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
-          <% if document.digital_objects.present? %>
+        <a class='nav-link <%= 'disabled' unless document.digital_objects.present? || document.online_content? %>' data-toggle='pill' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
+          <% if document.digital_objects.present? || document.online_content? %>
             <%= t 'arclight.views.show.online_content' %>
           <% else %>
             <%= t 'arclight.views.show.no_online_content' %>
@@ -33,7 +33,7 @@
         <%= render 'collection_contents' %>
       </div>
       <div class='tab-pane' id='online-content' role='tabpanel'>
-         <%= render_document_partial(document, 'arclight_viewer') %>
+        <%= render partial: 'collection_online_contents', locals: { document: document }  %>
       </div>
     </div>
   </div>

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -329,6 +329,12 @@ class CatalogController < ApplicationController
     config.view.hierarchy.partials = config.index.partials.dup
     config.view.hierarchy.partials.delete(:index_breadcrumb)
 
+    ##
+    # Hierarchy Index View
+    config.view.online_contents
+    config.view.online_contents.display_control = false
+    config.view.online_contents.partials = config.view.hierarchy.partials.dup
+
     # #
     # Compact index view
     config.view.compact

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -18,6 +18,21 @@ RSpec.describe CatalogController, type: :controller do
         expect(session[:preferred_view]).to eq 'list'
       end
     end
+
+    context 'online_contents view' do
+      it 'does not start a search_session' do
+        allow(controller).to receive(:search_results)
+        session[:history] = []
+        get :index, params: { q: 'foo', view: 'online_contents' }
+        expect(session[:history]).to be_empty
+      end
+      it 'does not store a preferred_view' do
+        allow(controller).to receive(:search_results)
+        session[:preferred_view] = 'list'
+        get :index, params: { q: 'foo', view: 'online_contents' }
+        expect(session[:preferred_view]).to eq 'list'
+      end
+    end
     context 'any other view' do
       it 'starts a search_session' do
         allow(controller).to receive(:search_results)

--- a/spec/features/online_content_spec.rb
+++ b/spec/features/online_content_spec.rb
@@ -34,6 +34,20 @@ RSpec.describe 'Online Content', type: :feature do
       end
     end
 
+    context 'a collection w/o digital objects at the collection level' do
+      let(:doc_id) { 'a0011-xml' }
+
+      it 'renders a flat list of the child components with online content', js: true do
+        click_link('Online content')
+
+        within('.documents-online_contents') do
+          expect(page).to have_css('article', count: 1)
+
+          expect(page).to have_css('.document-title-heading', text: 'Box 1: Photograph Album')
+        end
+      end
+    end
+
     context 'no content' do
       let(:doc_id) { 'aoa271aspace_a951375d104030369a993ff943f61a77' }
 


### PR DESCRIPTION
…to be displayed in the Online content tab in the absence of any collection level digital objects.

Closes #438 

## a0011-xml
<img width="1185" alt="a0011-xml-online-content" src="https://cloud.githubusercontent.com/assets/96776/26749164/dfca3b16-47ba-11e7-8284-69b1d0ecac59.png">