### PR TITLE
Update styling of request button and bookmark checkbox

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -24,6 +24,11 @@
     text-align: right;
   }
 
+  .bookmark-toggle,
+  .al-request-form {
+    font-size: $font-size-sm;
+  }
+
   // Component title + children badge
   .documentHeader {
     border-bottom: $border-width dashed #ccc;

--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -20,14 +20,27 @@
   }
 }
 
-.al-document-title-bar {
-  .toggle-bookmark {
-    @media (min-width: 576px) and (max-width: 991px) {
-      padding-right: $spacer;
-    }
-  }
+.bookmark-toggle .toggle-bookmark {
+  display: inline;
+  margin-bottom: 0;
+  white-space: nowrap;
 }
 
-.bookmark-toggle .toggle-bookmark {
-  margin-bottom: 0;
+.bookmark-toggle,
+.al-request-form {
+  display: inline;
+  float: right;
+}
+
+.al-request-form .al-request-button {
+  font-weight: 600;
+  line-height: 1;
+
+    @media (min-width: 1200px) {
+      margin-right: ($spacer / 2);
+    }
+
+  &:before {
+    content: "\0229F";
+  }
 }

--- a/app/views/arclight/requests/_google_form.html.erb
+++ b/app/views/arclight/requests/_google_form.html.erb
@@ -5,7 +5,7 @@
   <% google_form.form_mapping.each do |key, value| %>
     <%= hidden_field_tag value, google_form.send(key) %>
   <% end %>
-  <button type='submit' class='btn btn-sm btn-primary'>
+  <button type='submit' class='al-request-button btn-link'>
     <%= t('arclight.request.container') %>
   </button>
 <% end %>

--- a/app/views/catalog/_arclight_document_index_header.html.erb
+++ b/app/views/catalog/_arclight_document_index_header.html.erb
@@ -1,11 +1,11 @@
 <% document_actions = capture do %>
   <% # bookmark functions for items/docs -%>
-  <%= render_index_doc_actions document, wrapping_class: "col-5 col-sm-3 text-right" %>
+  <%= render_index_doc_actions document, wrapping_class: "col-sm-3 col-md-5 col-lg-4 text-right" %>
 <% end %>
 
 <div class='al-document-title-bar'>
   <div class='row'>
-    <div class='col-7 col-sm-9'>
+    <div class='col-sm-9 col-md-7 col-lg-8'>
       <%= document.repository_and_unitid %>
     </div>
     <%= document_actions %>

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -1,7 +1,7 @@
 <header class="documentHeader row" data-document-id="<%= document.id %>">
   <% requestable = item_requestable?('', { document: document }) %>
   <% side_content = document.children? || requestable %>
-  <h3 class="index_title document-title-heading <%= side_content ? 'col-md-9' : 'col-md-12' %> ">
+  <h3 class="index_title document-title-heading <%= side_content ? 'col-md-8' : 'col-md-12' %> ">
     <% if document.containers.present? %>
       <span class="document-title-containers">
         <%= document.containers.join(', ') %>:
@@ -11,7 +11,7 @@
     <%= link_to_document document, document_show_link_field(document), counter: counter %>
   </h3>
 
-  <div class="al-hierarchy-side-content float-right <%= side_content ? 'col-md-3' : 'col' %> ">
+  <div class="al-hierarchy-side-content float-right <%= side_content ? 'col-md-4' : 'col' %> ">
     <% unless hierarchy_component_context? %>
       <div class="index-document-functions">
         <%= render partial: 'catalog/bookmark_control', locals: { document: document } %>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -7,7 +7,7 @@ en:
       view_all: 'View'
       scope_and_contents: 'Scope and Contents'
     request:
-      container: 'Request container(s)'
+      container: 'Request'
     routes:
       home: 'Home'
       collections: 'Collections'

--- a/spec/features/google_form_request_spec.rb
+++ b/spec/features/google_form_request_spec.rb
@@ -20,7 +20,7 @@ describe 'Google Form Request', type: :feature, js: true do
           expect(page).to have_css 'input[name="entry.996397105"][value="aoa271"]', visible: false
           expect(page).to have_css 'input[name="entry.1125277048"][value="Box 1 Folder 1"]', visible: false
           expect(page).to have_css 'input[name="entry.862815208"][value$="William W. Root, n.d."]', visible: false
-          expect(page).to have_css 'button[type="submit"]', text: 'Request container(s)'
+          expect(page).to have_css 'button[type="submit"]', text: 'Request'
         end
       end
       context 'repository is not requestable' do


### PR DESCRIPTION
There are a number of issues we need to work out related to the styling and placement of accessory elements such as the request containers button, the bookmark checkbox, and the view hierarchy toggle. They're all related and somewhat complicated to sort out, so this PR is just a start. It only updates the styling of the request button so that it takes up less room, and places the request button and bookmark checkbox at the right-side of the elements they're in. I'll address the other related issues in future PRs.

Some examples:

### Before - bookmark button inconsistently placed and font larger than it is in other contexts
![before-3](https://user-images.githubusercontent.com/101482/26997791-89cd17c0-4d31-11e7-9bbc-f549e25f6e8f.png)

-- and -- 
![before-1](https://user-images.githubusercontent.com/101482/26997795-8d851250-4d31-11e7-8a89-b5ac5421a58e.png)

### After
![after-3](https://user-images.githubusercontent.com/101482/26997799-94b009ea-4d31-11e7-8501-26aa5da09ed5.png)

----
### Before - request button takes up a lot of space, requires new line for bookmark checkbox
![before-2](https://user-images.githubusercontent.com/101482/26997820-b077fcaa-4d31-11e7-82d8-3fdede20029e.png)

### After
![after-2](https://user-images.githubusercontent.com/101482/26997822-b857944e-4d31-11e7-8cb9-f62ebe742aa6.png)


