### PR TITLE
Split out and relocate the Download select on Collection show page

### DIFF
--- a/app/assets/stylesheets/arclight/modules/show_collection.scss
+++ b/app/assets/stylesheets/arclight/modules/show_collection.scss
@@ -76,3 +76,7 @@
     text-transform: uppercase;
   }
 }
+
+.al-collection-actions-menu {
+  float: right;
+}

--- a/app/views/catalog/_collection_downloads.html.erb
+++ b/app/views/catalog/_collection_downloads.html.erb
@@ -1,17 +1,15 @@
 <% if downloads.present? && (downloads[:pdf].present? || downloads[:ead].present?) %>
-<li>
-  <div class='dropdown'>
-    <button class='btn btn-secondary dropdown-toggle' type="button" id="download-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      <%= t 'arclight.views.show.download.default' %>
-    </button>
-    <div class="dropdown-menu" aria-labelledby="download-dropdown">
-      <% if downloads[:pdf].present? %>
-        <a class="dropdown-item" href="<%= downloads[:pdf][:href] %>"><%= t('arclight.views.show.download.pdf', size: downloads[:pdf][:size]) %></a>
-      <% end %>
-      <% if downloads[:ead].present? %>
-        <a class="dropdown-item" href="<%= downloads[:ead][:href] %>"><%= t('arclight.views.show.download.ead', size: downloads[:ead][:size]) %></a>
-      <% end  %>
-    </div>
+<div class='dropdown al-collection-actions-menu'>
+  <button class='btn btn-secondary btn-sm dropdown-toggle' type="button" id="download-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <%= t 'arclight.views.show.download.default' %>
+  </button>
+  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="download-dropdown">
+    <% if downloads[:pdf].present? %>
+      <a class="dropdown-item" href="<%= downloads[:pdf][:href] %>"><%= t('arclight.views.show.download.pdf', size: downloads[:pdf][:size]) %></a>
+    <% end %>
+    <% if downloads[:ead].present? %>
+      <a class="dropdown-item" href="<%= downloads[:ead][:href] %>"><%= t('arclight.views.show.download.ead', size: downloads[:ead][:size]) %></a>
+    <% end  %>
   </div>
-</li>
+</div>
 <% end %>

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -3,28 +3,36 @@
     <%= render partial: 'show_sidebar' %>
   </div>
   <div class='col-md-9'>
-    <ul class='nav nav-pills' role='tablist'>
-      <li class='nav-item'>
-        <a class='nav-link active' data-toggle='pill' href='#overview' role='tab'>
-          <%= t 'arclight.views.show.overview' %>
-        </a>
-      </li>
-      <li class='nav-item'>
-        <a class='nav-link disabled' data-toggle='pill' href='#contents' role='tab' data-hierarchy-enable-me='true'>
-          <%= t 'arclight.views.show.no_contents' %>
-        </a>
-      </li>
-      <li class='nav-item'>
-        <a class='nav-link <%= 'disabled' unless document.digital_objects.present? || document.online_content? %>' data-toggle='pill' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
-          <% if document.digital_objects.present? || document.online_content? %>
-            <%= t 'arclight.views.show.online_content' %>
-          <% else %>
-            <%= t 'arclight.views.show.no_online_content' %>
-          <% end %>
-        </a>
-      </li>
-      <%= render partial: 'collection_downloads', locals: { downloads: collection_downloads(document) } %>
-    </ul>
+    <div class='row'>
+      <div class='col-lg-9'>
+        <ul class='nav nav-pills' role='tablist'>
+          <li class='nav-item'>
+            <a class='nav-link active' data-toggle='pill' href='#overview' role='tab'>
+              <%= t 'arclight.views.show.overview' %>
+            </a>
+          </li>
+          <li class='nav-item'>
+            <a class='nav-link disabled' data-toggle='pill' href='#contents' role='tab' data-hierarchy-enable-me='true'>
+              <%= t 'arclight.views.show.no_contents' %>
+            </a>
+          </li>
+          <li class='nav-item'>
+            <a class='nav-link <%= 'disabled' unless document.digital_objects.present? || document.online_content? %>' data-toggle='pill' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
+              <% if document.digital_objects.present? || document.online_content? %>
+                <%= t 'arclight.views.show.online_content' %>
+              <% else %>
+                <%= t 'arclight.views.show.no_online_content' %>
+              <% end %>
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div class='col'>
+        <%= render partial: 'collection_downloads', locals: { downloads: collection_downloads(document) } %>
+      </div>
+    </div>
+
     <div class='tab-content'>
       <div class='tab-pane active' id='overview' role='tabpanel'>
         <%= render 'collection_overview' %>


### PR DESCRIPTION
Currently, the Download select menu on the collection show page is part of the set of tabs that control your view of the collection:

![abdeen_jabara_papers__1956-1994__bulk_1968-1993_-_arclight](https://user-images.githubusercontent.com/101482/27052110-6fc2391c-4f6d-11e7-906b-d6050083c35d.png)

----
However, the Download action is very different from those tabs and to prevent confusion should be visually separated. This PR moves the Download button to be right-aligned on the page by taking it out of the current set of nav items:

![alpha_omega_alpha_archives__1894-1992_-_arclight](https://user-images.githubusercontent.com/101482/27052040-3695012e-4f6d-11e7-9cc5-f4c99f984902.png)
----
At medium and smaller viewports the Download button is bumped down to a separate row to keep the visual separation:

![alpha_omega_alpha_archives__1894-1992_-_arclight 2](https://user-images.githubusercontent.com/101482/27052086-5883d5b2-4f6d-11e7-94eb-2d0f3e0bc29c.png)

