### PR TITLE
Style request button differently in sidebar

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -26,21 +26,27 @@
   white-space: nowrap;
 }
 
-.bookmark-toggle,
-.al-request-form {
+.bookmark-toggle {
   display: inline;
   float: right;
 }
 
-.al-request-form .al-request-button {
-  font-weight: 600;
-  line-height: 1;
+.al-hierarchy-side-content {
+  .al-request-form {
+    display: inline;
+    float: right;
+  }
 
-    @media (min-width: 1200px) {
-      margin-right: ($spacer / 2);
+  .al-request-button {
+    font-weight: 600;
+    line-height: 1;
+
+      @media (min-width: 1200px) {
+        margin-right: ($spacer / 2);
+      }
+
+    &:before {
+      content: "\0229F";
     }
-
-  &:before {
-    content: "\0229F";
   }
 }

--- a/app/assets/stylesheets/arclight/modules/sidebar.scss
+++ b/app/assets/stylesheets/arclight/modules/sidebar.scss
@@ -14,3 +14,8 @@
 dt.blacklight-digital_objects_ssm {
   display: none;
 }
+
+.al-sticky-sidebar .al-request-button {
+  border: 0;
+  padding-left: 0;
+}


### PR DESCRIPTION
A previous PR to re-style the request button/link didn't take into account how that styling would affect the request button when presented in the component page sidebar:

![_a_brief_account_of_the_origin_of_the_alpha_omega_alpha_honorary_fraternity__-_william_w__root__n_d__-_arclight 2](https://user-images.githubusercontent.com/101482/27200394-60c1c136-51ce-11e7-897d-62273fe03604.png)
----
This PR just updates the CSS so the sidebar version of the request link is better aligned:

![_a_brief_account_of_the_origin_of_the_alpha_omega_alpha_honorary_fraternity__-_william_w__root__n_d__-_arclight](https://user-images.githubusercontent.com/101482/27200420-7a3abc80-51ce-11e7-91bf-2bee90ff4562.png)
----
The display in the hierarchy context is unchanged:
![alpha_omega_alpha_archives__1894-1992_-_arclight](https://user-images.githubusercontent.com/101482/27200448-8bfec614-51ce-11e7-9125-e96e641c230c.png)
