### PR TITLE
Relocate online content badge when in hierarchy

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -1,4 +1,8 @@
 .documents-list {
+  .badge {
+    float: right;
+  }
+
   // Result item header
   .al-document-title-bar {
     background-color: $gray-lighter;

--- a/app/assets/stylesheets/arclight/modules/show_collection.scss
+++ b/app/assets/stylesheets/arclight/modules/show_collection.scss
@@ -59,6 +59,10 @@
     padding: 3px $result-item-body-padding;
   }
 
+  .badge {
+    float: right;
+  }
+
   h1 {
     font-size: $font-size-h4;
     margin-bottom: $spacer;

--- a/app/views/catalog/_arclight_online_content_indicator.html.erb
+++ b/app/views/catalog/_arclight_online_content_indicator.html.erb
@@ -1,5 +1,5 @@
 <% if document.online_content? %>
-  <span class='badge badge-success float-right'>
+  <span class='badge badge-success'>
     <%= t(:'arclight.views.online_content_indicator') %>
   </span>
 <% end %>

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -9,6 +9,7 @@
     <% end %>
     <% counter = document_counter_with_offset(document_counter) %>
     <%= link_to_document document, document_show_link_field(document), counter: counter %>
+    <%= render_document_partial(document, 'arclight_online_content_indicator') %>
   </h3>
 
   <div class="al-hierarchy-side-content float-right <%= side_content ? 'col-md-4' : 'col' %> ">

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -227,7 +227,7 @@ class CatalogController < ApplicationController
       two_words_connector: '<br/>',
       last_word_connector: '<br/>'
     }
-    
+
     # Collection Show Page - Indexed Terms Section
     config.add_component_indexed_terms_field 'access_subjects_ssim', label: 'Subjects', :link_to_facet => true, separator_options: {
       words_connector: '<br/>',
@@ -328,6 +328,7 @@ class CatalogController < ApplicationController
     config.view.hierarchy.display_control = false
     config.view.hierarchy.partials = config.index.partials.dup
     config.view.hierarchy.partials.delete(:index_breadcrumb)
+    config.view.hierarchy.partials.delete(:arclight_online_content_indicator)
 
     ##
     # Hierarchy Index View


### PR DESCRIPTION
To keep the request and bookmark controls in a consistent place (right-aligned) in the content inventory hierarchy, this PR moves the online content badge from the right-side of the page to the end of the component title:

![alpha_omega_alpha_archives__1894-1992_-_arclight](https://user-images.githubusercontent.com/101482/27204090-f557ec08-51dd-11e7-9343-17515c4f01b0.png)

The goal is only to move the badge in the hierarchy context, not the search results or other contexts.