### PR TITLE
Add class to fix overlapping toggle/icon issue

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-toggleable-md navbar-inverse bg-inverse" role="navigation">
+<nav class="navbar navbar-toggleable-md navbar-inverse bg-inverse topbar" role="navigation">
   <div class="<%= container_classes %>">
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Fixes #266 

Added class so we pick up styling from Blacklight that prevents the application icon and example toggle from overlapping at small viewport sizes.

Fix looks like this:

![alpha_omega_alpha_archives__1894-1992_-_arclight 2](https://user-images.githubusercontent.com/101482/27204434-0cf5c572-51e0-11e7-967e-089449333f58.png)
