### PR TITLE
Relocate view children toggle to prevent overlap with side content

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -21,7 +21,9 @@
   }
 
   .al-hierarchy-children-status {
-    text-align: right;
+    font-size: $font-size-h6;
+    margin-top: 6px;
+    text-align: left;
   }
 
   .bookmark-toggle,
@@ -79,26 +81,26 @@
     .blacklight-subseries .document-title-heading,
     .al-hierarchy-level-1 .blacklight-file .document-title-heading,
     .al-hierarchy-level-1 .blacklight-otherlevel .document-title-heading {
-      border-left: ($border-width * 2) solid #999;
       padding-left: 10px;
+
+      &:before {
+        color: $gray-light;
+        content: "\027E9";
+        padding-right: 3px;
+      }
     }
 
     .al-hierarchy-level-2 .document-title-heading,
     .al-hierarchy-level-2 .blacklight-file .document-title-heading {
-      border-left: 0;
-      padding-left: 0;
-
       &:before {
-        color: $gray-light;
-        content: "\a6";
-        padding-right: 6px;
+        content: "\027E9 \027E9";
       }
     }
 
     .al-hierarchy-level-3 .document-title-heading,
     .al-hierarchy-level-3 .blacklight-file .document-title-heading {
       &:before {
-        content: "\205D";
+        content: "\027E9 \027E9 \027E9";
       }
     }
   }
@@ -167,10 +169,10 @@
 @mixin hierarchy-levels {
   @for $i from 1 through 12 {
     .al-hierarchy-level-#{$i} {
-      margin-left: 10px;
+      margin-left: 20px;
       // provides for n indention
       &.extra-indent {
-        margin-left: ($i * 10) + px;
+        margin-left: ($i * 20) + px;
       }
     }
   }

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -9,17 +9,6 @@
     <% counter = document_counter_with_offset(document_counter) %>
     <%= link_to_document document, document_show_link_field(document), counter: counter %>
     <%= render_document_partial(document, 'arclight_online_content_indicator') %>
-  </h3>
-
-  <div class="al-hierarchy-side-content float-right col">
-    <% unless hierarchy_component_context? %>
-      <div class="index-document-functions">
-        <%= render partial: 'catalog/bookmark_control', locals: { document: document } %>
-      </div>
-    <% end %>
-    <% if requestable %>
-      <%= render partial: 'arclight/requests/google_form', locals: { document: document } %>
-    <% end %>
     <% if document.children? %>
       <div class='al-hierarchy-children-status'>
         <span class='badge badge-default al-number-of-children-badge'>
@@ -37,6 +26,17 @@
           <% end %>
         </span>
       </div>
+    <% end %>
+  </h3>
+
+  <div class="al-hierarchy-side-content float-right col">
+    <% unless hierarchy_component_context? %>
+      <div class="index-document-functions">
+        <%= render partial: 'catalog/bookmark_control', locals: { document: document } %>
+      </div>
+    <% end %>
+    <% if requestable %>
+      <%= render partial: 'arclight/requests/google_form', locals: { document: document } %>
     <% end %>
   </div>
 </header>


### PR DESCRIPTION
Moves the toggle from the right-side to the left, which can be crowded now with the request and bookmark controls.

![milton_friedman_papers__1931-2006_-_arclight](https://user-images.githubusercontent.com/101482/27205817-fee47bf6-51e7-11e7-8508-404221ad2ba8.png)
