### PR TITLE
bootstrap 4 beta changes

### DIFF
--- a/app/assets/stylesheets/arclight/application.scss
+++ b/app/assets/stylesheets/arclight/application.scss
@@ -1,3 +1,4 @@
+@import 'bootstrap/functions';
 @import 'bootstrap/variables';
 @import 'bootstrap_overrides';
 @import 'variables';

--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -1,7 +1,7 @@
 .documents-hierarchy,
 .documents-online_contents {
   .document-title-heading {
-    font-size: $font-size-h5;
+    font-size: $h5-font-size;
   }
 
   .document-title-containers {
@@ -11,17 +11,17 @@
   }
 
   .al-toggle-view-all {
-    color: $gray-light;
+    color: $gray-600;
 
     &:before {
-      color: $gray-light;
+      color: $gray-600;
       content: "\2022";
       padding-right: 3px;
     }
   }
 
   .al-hierarchy-children-status {
-    font-size: $font-size-h6;
+    font-size: $h6-font-size;
     margin-top: 6px;
     text-align: left;
   }
@@ -45,8 +45,8 @@
   }
 
   .al-hierarchy-sub-heading {
-    color: $gray-light;
-    font-size: $font-size-xs;
+    color: $gray-600;
+    font-size: $font-size-sm;
     font-weight: normal;
     text-transform: uppercase;
   }
@@ -55,12 +55,12 @@
   .blacklight-series .document-title-heading,
   .blacklight-file .document-title-heading,
   .blacklight-otherlevel .document-title-heading {
-    font-size: $font-size-h5;
+    font-size: $h5-font-size;
     font-weight: 400;
     margin-bottom: ($spacer / 2);
 
     > a {
-      color: $gray-dark;
+      color: $gray-900;
     }
   }
 
@@ -70,7 +70,7 @@
     .blacklight-subseries .document-title-heading,
     .blacklight-file .document-title-heading,
     .blacklight-otherlevel .document-title-heading {
-      font-size: $font-size-h6;
+      font-size: $h6-font-size;
 
       .documentHeader {
         margin-top: $spacer;
@@ -84,7 +84,7 @@
       padding-left: 10px;
 
       &:before {
-        color: $gray-light;
+        color: $gray-600;
         content: "\027E9";
         padding-right: 3px;
       }
@@ -107,7 +107,7 @@
 }
 
 .al-hierarchy-highlight {
-  background: $state-warning-bg;
+  background: $mark-bg;
 }
 
 // Placeholder styling
@@ -115,13 +115,13 @@
   margin-top: $spacer;
 
   h3 {
-    background-color: $gray-lighter;
+    background-color: $gray-200;
     border-radius: 5px;
-    height: $font-size-h3;
+    height: $h3-font-size;
   }
 
   p {
-    background-color: $gray-lighter;
+    background-color: $gray-200;
     border-radius: 5px;
     height: $font-size-base;
   }
@@ -130,7 +130,7 @@
 // Component show page, Collection context section
 #collection-context {
   h1 {
-    font-size: $font-size-h5;
+    font-size: $h5-font-size;
   }
 
   .documents-hierarchy,
@@ -143,23 +143,23 @@
   // Top-level context
   .al-hierarchy-level-0 .document-title-heading {
     // background-color: red;
-    font-size: $font-size-h5;
+    font-size: $h5-font-size;
     font-weight: 400;
     margin-bottom: ($spacer / 2);
 
     > a {
-      color: $gray-dark;
+      color: $gray-900;
     }
   }
 
   // All subsequent levels
   @for $i from 1 through 12 {
     .al-hierarchy-level-#{$i} .document-title-heading {
-      font-size: $font-size-h6;
+      font-size: $h6-font-size;
       font-weight: 400;
 
       > a {
-        color: $gray-dark;
+        color: $gray-900;
       }
     }
   }

--- a/app/assets/stylesheets/arclight/modules/highlights.scss
+++ b/app/assets/stylesheets/arclight/modules/highlights.scss
@@ -1,7 +1,7 @@
 .al-document-highlight {
   padding-top: 10px;
   padding-left: 10px;
-  font-size: $font-size-xs;
+  font-size: $font-size-sm;
   font-style: italic;
   em {
     background-color: yellow;

--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -23,7 +23,7 @@
 
 .al-masthead {
   h1 {
-    font-size: $font-size-h2;
+    font-size: $h2-font-size;
     margin: 0;
     padding: ($spacer * 1.5) ($spacer / 2);
   }
@@ -38,7 +38,7 @@
     }
 
     .active a {
-      color: $gray;
+      color: $gray-700;
     }
 
     .navbar-toggler {
@@ -47,7 +47,7 @@
     }
 
     .navbar-toggler-icon {
-      background-image: $navbar-light-toggler-bg;
+      background-image: $navbar-light-toggler-icon-bg;
     }
   }
 

--- a/app/assets/stylesheets/arclight/modules/repositories.scss
+++ b/app/assets/stylesheets/arclight/modules/repositories.scss
@@ -4,7 +4,7 @@
     margin-top: ($spacer * 2);
 
     h3 {
-      font-size: $font-size-h4;
+      font-size: $h4-font-size;
     }
   }
 

--- a/app/assets/stylesheets/arclight/modules/repository_card.scss
+++ b/app/assets/stylesheets/arclight/modules/repository_card.scss
@@ -1,5 +1,5 @@
 .al-repository {
-  background-color: $gray-lighter;
+  background-color: $gray-200;
   border: $result-item-border-styling;
   margin-bottom: $spacer;
 
@@ -12,7 +12,7 @@
     }
 
     h2 {
-      font-size: $font-size-h5;
+      font-size: $h5-font-size;
       margin-bottom: $spacer;
     }
 

--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -5,7 +5,7 @@
 
   // Result item header
   .al-document-title-bar {
-    background-color: $gray-lighter;
+    background-color: $gray-200;
     border: $result-item-border-styling;
     font-size: $font-size-sm;
     margin: 0 (-$result-item-body-padding - 1px) 0.5rem;
@@ -25,7 +25,7 @@
     }
 
     .document-title-heading {
-      font-size: $font-size-h5;
+      font-size: $h5-font-size;
     }
 
     .breadcrumb-links,
@@ -50,7 +50,7 @@
   .al-number-of-children-badge {
     background-color: #eee;
     border: 1px solid #ccc;
-    color: $gray-light;
+    color: $gray-600;
     vertical-align: top;
   }
 }

--- a/app/assets/stylesheets/arclight/modules/show_collection.scss
+++ b/app/assets/stylesheets/arclight/modules/show_collection.scss
@@ -9,14 +9,14 @@
   }
 
   .card-header h3 {
-    font-size: $font-size-h6;
+    font-size: $h6-font-size;
     font-weight: $font-weight-normal;
   }
 
   // Sidebar sections
   dt {
-    color: $gray;
-    font-size: $font-size-xs;
+    color: $gray-700;
+    font-size: $font-size-sm;
     font-weight: $font-weight-bold;
     margin-bottom: 3px;
     text-transform: uppercase;
@@ -52,7 +52,7 @@
   padding: 0 $spacer;
 
   .al-document-title-bar {
-    background-color: $gray-lighter;
+    background-color: $gray-200;
     border-bottom: $result-item-border-styling;
     font-size: $font-size-sm;
     margin: 0 (-$spacer) $spacer;
@@ -64,18 +64,18 @@
   }
 
   h1 {
-    font-size: $font-size-h4;
+    font-size: $h4-font-size;
     margin-bottom: $spacer;
   }
 }
 
 // Collection overview
 .al-show-sub-heading {
-  font-size: $font-size-h6;
+  font-size: $h6-font-size;
   text-transform: uppercase;
 
   + dl dt {
-    font-size: $font-size-xs;
+    font-size: $font-size-sm;
     margin-top: 4px;
     text-transform: uppercase;
   }

--- a/app/views/catalog/_context_card.html.erb
+++ b/app/views/catalog/_context_card.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div id="collapse<%= card_index %>" class="collapse <%= 'show' if card_index.zero? %>" role="tabpanel" aria-labelledby="heading<%= card_index %>">
-    <div class="card-block">
+    <div class="card-body">
       <dl>
         <% generic_document_fields(field_accessor).each do |field_name, field| %>
           <% if generic_should_render_field?(field_accessor, document, field) %>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -4,7 +4,7 @@
     <div class='card-header'>
       <h3 class="mb-0">Search within this collection</h3>
     </div>
-    <div class='card-block'>
+    <div class='card-body'>
       <%= render 'search_within_form' %>
     </div>
   </div>
@@ -12,7 +12,7 @@
     <div class='card-header'>
       <h3 class="mb-0"><%= t('arclight.views.show.navigation_sidebar.title') %></h3>
     </div>
-    <div class='card-block'>
+    <div class='card-body'>
       <ul class='nav nav-pills flex-column'>
         <% unless blacklight_config.show.metadata_partials.nil? %>
           <% blacklight_config.show.metadata_partials.each do |item| %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,10 +1,11 @@
-<nav class="navbar navbar-toggleable-md navbar-inverse bg-inverse topbar" role="navigation">
+<nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" role="navigation">
   <div class="<%= container_classes %>">
+    <%= link_to application_name, root_path, class: "navbar-brand" %>
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
 
-    <%= link_to application_name, root_path, class: "navbar-brand" %>
+    
 
     <div class="collapse navbar-collapse justify-content-md-end" id="user-util-collapse">
       <%= render 'shared/user_util_links' %>
@@ -15,12 +16,12 @@
 <% if controller_name == 'catalog' && !has_search_parameters? && action_name == 'index' %>
   <div class='al-homepage-masthead jumbotron'>
     <div class='row'>
-      <div class='col-md-8 offset-md-2'>
+      <div class='col-md-8 ml-auto'>
         <h1 class='text-center'><%= t('arclight.masthead_heading') %></h1>
       </div>
     </div>
     <div class='row'>
-      <div class='col-md-6 offset-md-3'>
+      <div class='col-md-6 ml-auto'>
         <div class='navbar-search'>
           <%= render_search_bar %>
         </div>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -168,11 +168,11 @@ RSpec.describe 'Collection Page', type: :feature do
         it 'has an in person card' do
           within '#accordion' do
             expect(page).to have_css '.card-header h3', text: 'In person'
-            expect(page).to have_css '.card-block dt', text: 'Before you visit:'
-            expect(page).to have_css '.card-block dd', text: /materials are stored offsite and must be paged/
-            expect(page).to have_css '.card-block dt', text: 'Location of this collection:'
-            expect(page).to have_css '.card-block dd a', text: /Special Collections and University Archives/
-            expect(page).to have_css '.card-block dd .al-repository-contact-building', text: 'Green Library'
+            expect(page).to have_css '.card-body dt', text: 'Before you visit:'
+            expect(page).to have_css '.card-body dd', text: /materials are stored offsite and must be paged/
+            expect(page).to have_css '.card-body dt', text: 'Location of this collection:'
+            expect(page).to have_css '.card-body dd a', text: /Special Collections and University Archives/
+            expect(page).to have_css '.card-body dd .al-repository-contact-building', text: 'Green Library'
           end
         end
       end
@@ -180,18 +180,18 @@ RSpec.describe 'Collection Page', type: :feature do
       it 'has a terms and conditions card' do
         within '#accordion' do
           expect(page).to have_css '.card-header h3', text: 'Terms & Conditions'
-          expect(page).to have_css '.card-block dt', text: 'Restrictions:'
-          expect(page).to have_css '.card-block dd', text: 'No restrictions on access.'
-          expect(page).to have_css '.card-block dt', text: 'Terms of Access:'
-          expect(page).to have_css '.card-block dd', text: /^Copyright was transferred/
+          expect(page).to have_css '.card-body dt', text: 'Restrictions:'
+          expect(page).to have_css '.card-body dd', text: 'No restrictions on access.'
+          expect(page).to have_css '.card-body dt', text: 'Terms of Access:'
+          expect(page).to have_css '.card-body dd', text: /^Copyright was transferred/
         end
       end
 
       it 'has a how to cite card' do
         within '#accordion' do
           expect(page).to have_css '.card-header h3', text: 'How to cite this collection'
-          expect(page).to have_css '.card-block dt', text: 'Preferred citation'
-          expect(page).to have_css '.card-block dd', text: /Omega Alpha Archives\. 1894-1992/
+          expect(page).to have_css '.card-body dt', text: 'Preferred citation'
+          expect(page).to have_css '.card-body dd', text: /Omega Alpha Archives\. 1894-1992/
         end
       end
     end

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -79,10 +79,10 @@ RSpec.describe 'Component Page', type: :feature do
         it 'has a terms and conditions card' do
           within '#accordion' do
             expect(page).to have_css('.card-header h3', text: 'Terms & Conditions')
-            expect(page).to have_css('.card-block dt', text: 'Restrictions:')
-            expect(page).to have_css('.card-block dd', text: 'No restrictions on access.')
-            expect(page).to have_css('.card-block dt', text: 'Terms of Access:')
-            expect(page).to have_css('.card-block dd', text: /^Copyright was transferred to the public domain./)
+            expect(page).to have_css('.card-body dt', text: 'Restrictions:')
+            expect(page).to have_css('.card-body dd', text: 'No restrictions on access.')
+            expect(page).to have_css('.card-body dt', text: 'Terms of Access:')
+            expect(page).to have_css('.card-body dd', text: /^Copyright was transferred to the public domain./)
           end
         end
       end
@@ -90,8 +90,8 @@ RSpec.describe 'Component Page', type: :feature do
         it 'has an in person card' do
           within '#accordion' do
             expect(page).to have_css '.card-header h3', text: 'In person'
-            expect(page).to have_css '.card-block dt', text: 'Location of this collection:'
-            expect(page).to have_css '.card-block dd .al-repository-contact-building', text: 'Building 38, Room 1E-21'
+            expect(page).to have_css '.card-body dt', text: 'Location of this collection:'
+            expect(page).to have_css '.card-body dd .al-repository-contact-building', text: 'Building 38, Room 1E-21'
           end
         end
       end


### PR DESCRIPTION
The master branch of Blacklight recently updated Bootstrap 4 from alpha to beta, deprecating a number of variables used throughout Arclight, resulting in a number of "variable not found" errors when attempting to install the application. This PR addresses the variable name changes to at least the point of getting Arclight up and running again. Some additional styling/formatting work is still needed.