### PR TITLE
Update bootstrap classes on home page to address issues with…

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -15,20 +15,18 @@
 
 <% if controller_name == 'catalog' && !has_search_parameters? && action_name == 'index' %>
   <div class='al-homepage-masthead jumbotron'>
-    <div class='row'>
-      <div class='col-md-8 ml-auto'>
-        <h1 class='text-center'><%= t('arclight.masthead_heading') %></h1>
-      </div>
+    <div class='d-flex justify-content-center'>
+      <h1 class='text-center'><%= t('arclight.masthead_heading') %></h1>
     </div>
-    <div class='row'>
-      <div class='col-md-6 ml-auto'>
+    <div class='row justify-content-md-center'>
+      <div class='col-md-6 col-sm-12'>
         <div class='navbar-search'>
           <%= render_search_bar %>
         </div>
       </div>
     </div>
-    <nav class="navbar" role="navigation">
-      <ul class="nav justify-content-center">
+    <nav class="navbar justify-content-center" role="navigation">
+      <ul class="nav">
         <%= render 'shared/main_menu_links' %>
       </ul>
     </nav>


### PR DESCRIPTION
…version of BS4.

## Before
<img width="1585" alt="before" src="https://user-images.githubusercontent.com/96776/30825706-cbef7006-a1e8-11e7-8a4e-015889987ccb.png">

## After
<img width="1189" alt="after" src="https://user-images.githubusercontent.com/96776/30825708-cbf8ef82-a1e8-11e7-9401-a6d2a905efad.png">

---

![after](https://user-images.githubusercontent.com/96776/30825707-cbef7448-a1e8-11e7-8b5a-6f8df8358409.gif)






