### PR TITLE
Solr 7 changes

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -3,4 +3,3 @@
 collection:
   dir: solr/conf/
   name: blacklight-core
-version: 6.6.1

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -531,11 +531,6 @@
    -->
  <uniqueKey>id</uniqueKey>
 
- <!-- field for the QueryParser to use when an explicit fieldname is absent -->
- <defaultSearchField>text</defaultSearchField>
-
- <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
 
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,


### PR DESCRIPTION
* Remove solr_wrapper's pin to Solr 6.6.1
* Remove defaultSearch field and solrQueryParser's defaultOperator setting in Solr schema