### PR TITLE
component levels display a Contents tab that allows navigation to children

### DIFF
--- a/app/views/catalog/_component_contents.html.erb
+++ b/app/views/catalog/_component_contents.html.erb
@@ -1,0 +1,16 @@
+<% document ||= @document %>
+<% @sub_level ||= document.component_level + 1 %>
+
+
+<h2 class="sr-only">Component inventory</h2>
+	<div class="component-level-only">
+	<%= content_tag(
+	  :div, '',
+	  class: 'al-contents',
+	  data: {
+	    arclight: {
+	      hierarchy: true, level: @sub_level, path: search_catalog_path, name: document.collection_name, parent: document.reference
+	    }
+	  }
+	) %>
+	</div>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -9,6 +9,13 @@
           <%= t 'arclight.views.show.overview' %>
         </a>
       </li>
+      <% if document.children? %>
+        <li class='nav-item'>
+              <a class='nav-link disabled' data-toggle='pill' href='#contents' role='tab' data-hierarchy-enable-me='true'>
+                <%= t 'arclight.views.show.no_contents' %>
+              </a>
+        </li>
+      <% end %>
       <li class='nav-item'>
         <a class='nav-link <%= 'disabled' unless document.online_content? %>' data-toggle='pill' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
           <% if document.online_content? %>
@@ -22,6 +29,9 @@
     <div class='tab-content'>
       <div class='tab-pane active' id='overview' role='tabpanel'>
         <%= render 'component_overview' %>
+      </div>
+      <div class='tab-pane' id='contents' role='tabpanel'>
+        <%= render 'component_contents' %>
       </div>
       <div class='tab-pane' id='online-content' role='tabpanel'>
         <%= render_document_partial(document, 'arclight_viewer') %>


### PR DESCRIPTION
I'm not sure if there is a reason this was done this way, but prior to this pull request, it was not possible to navigate from a component (such as a series or subseries) to its children.

This adds a Contents tab, like in Collections, to lower level components with children. This way if you end up in a series/subseries from a search, you can still see and navigate to all lower-level children.