### PR TITLE
Fixed Issue #487

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -39,7 +39,7 @@ module ArclightHelper
   end
 
   def collection_count
-    facets_from_request.find { |f| f.name == 'collection_sim' }.try(:items).try(:count)
+    @response.response['numFound']
   end
 
   ##


### PR DESCRIPTION
A search for collections now uses the numFound field in the response instead of the facets, which was limited to 100. Addresses issue #487